### PR TITLE
fixed 'changeLogCreateTables.xml' to recognize psql 9 and greater

### DIFF
--- a/core/src/main/resources/migration/2.5/changeLogCreateTables.xml
+++ b/core/src/main/resources/migration/2.5/changeLogCreateTables.xml
@@ -5,7 +5,7 @@
         <validCheckSum>30d56b8377711e93debdac333aa217d</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <dbms type="postgresql" />
-            <sqlCheck expectedResult="t"> <![CDATA[select substring(replace((string_to_array(version(), ' '))[2],'.','')from 1 for 2)::integer < 90 ]]></sqlCheck>
+            <sqlCheck expectedResult="t"> <![CDATA[select current_setting('server_version_num')::integer < 90000 ]]></sqlCheck>
         </preConditions>
         <sql splitStatements="false">
             DROP LANGUAGE IF EXISTS plpgsql;


### PR DESCRIPTION
fixed 'changeLogCreateTables.xml' liquibase script to detect if the used postgres version is 9.0 or greater