### PR TITLE
Fix for deleting an Event CRF results in oops page

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/dao/hibernate/DynamicsItemFormMetadataDao.java
+++ b/core/src/main/java/org/akaza/openclinica/dao/hibernate/DynamicsItemFormMetadataDao.java
@@ -19,6 +19,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  *
@@ -234,11 +235,12 @@ public class DynamicsItemFormMetadataDao extends AbstractDomainDao<DynamicsItemF
         }
         return HibernateUtil.queryIDsList(q);
     }
-    
-    public  void delete(int eventCrfId){
-        String query = " delete from " + getDomainClassName() +  "  where eventCrfId =:eventCrfId ";
-        org.hibernate.Query q = getCurrentSession().createQuery(query);
-        q.setInteger("eventCrfId", eventCrfId);
+
+    @Transactional
+    public void delete(int eventCrfId) {
+        String query = "delete from " + getDomainClassName() + " metadata where metadata.eventCrfId = :eventCrfId";
+        org.hibernate.query.Query q = getCurrentSession().createQuery(query);
+        q.setParameter("eventCrfId", eventCrfId);
         q.executeUpdate();
     }
 

--- a/core/src/main/java/org/akaza/openclinica/dao/hibernate/DynamicsItemGroupMetadataDao.java
+++ b/core/src/main/java/org/akaza/openclinica/dao/hibernate/DynamicsItemGroupMetadataDao.java
@@ -11,6 +11,7 @@ import org.akaza.openclinica.bean.submit.EventCRFBean;
 import org.akaza.openclinica.bean.submit.ItemGroupMetadataBean;
 import org.akaza.openclinica.dao.core.CoreResources;
 import org.akaza.openclinica.domain.crfdata.DynamicsItemGroupMetadataBean;
+import org.springframework.transaction.annotation.Transactional;
 
 public class DynamicsItemGroupMetadataDao extends AbstractDomainDao<DynamicsItemGroupMetadataBean>{
 
@@ -64,10 +65,12 @@ public class DynamicsItemGroupMetadataDao extends AbstractDomainDao<DynamicsItem
         q.setInteger("crfVersionId", crfVersionId);
         return q.list() != null && q.list().size() > 0;
     }
-    public  void delete(int eventCrfId){
-        String query = " delete from " + getDomainClassName() +  "  where eventCrfId =:eventCrfId ";
-        org.hibernate.Query q = getCurrentSession().createQuery(query);
-        q.setInteger("eventCrfId", eventCrfId);
+
+    @Transactional
+    public void delete(int eventCrfId) {
+        String query = "delete from " + getDomainClassName() + " metadata where metadata.eventCrfId = :eventCrfId";
+        org.hibernate.query.Query q = getCurrentSession().createQuery(query);
+        q.setParameter("eventCrfId", eventCrfId);
         q.executeUpdate();
     }
 

--- a/core/src/main/java/org/akaza/openclinica/dao/hibernate/RuleActionRunLogDao.java
+++ b/core/src/main/java/org/akaza/openclinica/dao/hibernate/RuleActionRunLogDao.java
@@ -26,11 +26,12 @@ public class RuleActionRunLogDao extends AbstractDomainDao<RuleActionRunLogBean>
         return k.intValue();
     }
 
-    public  void delete(int itemDataId){
-            String query = " delete from " + getDomainClassName() +  "  where itemDataId =:itemDataId ";
-            org.hibernate.Query q = getCurrentSession().createQuery(query);
-            q.setInteger("itemDataId", itemDataId);
-            q.executeUpdate();
-        }
+    @Transactional
+    public void delete(int itemDataId) {
+        String query = "delete from " + getDomainClassName() + " rarl where rarl.itemDataId = :itemDataId";
+        org.hibernate.query.Query q = getCurrentSession().createQuery(query);
+        q.setParameter("itemDataId", itemDataId);
+        q.executeUpdate();
+    }
 
 }


### PR DESCRIPTION
Transactional processing of delete actions during DeleteEventCRF request.

Copyright in one file was marked as changed but I only expanded it (as I was reading its content).