### PR TITLE
Correct the spreadsheet servlet which was overwritten with old copyright and error logging

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/admin/DownloadVersionSpreadSheetServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/admin/DownloadVersionSpreadSheetServlet.java
@@ -1,8 +1,8 @@
-/* OpenClinica is distributed under the
+/* LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
 
- * For details see: http://www.openclinica.org/license
- * copyright 2003-2005 Akaza Research
+ * For details see: https://libreclinica.org/license
+ * LibreClinica, copyright (C) 2020
  */
 package org.akaza.openclinica.control.admin;
 
@@ -129,7 +129,7 @@ public class DownloadVersionSpreadSheetServlet extends SecureController {
                 op.flush();
                 op.close();
             } catch (Exception ee) {
-                ee.printStackTrace();
+                logger.error("Input Stream is not working properly: ", ee);
             } finally {
                 if (in != null) {
                     in.close();


### PR DESCRIPTION
When the new CRF template for LC was merged to lc-develop:

https://github.com/reliatec-gmbh/LibreClinica/commit/ac608e954fa54cbbc42a7882d8f1439ad4e7bdfd

The servlet came in with old copyright and overwrote the fixed logging. This pull request is just to correct those things and keep the new LC CRF template as it was committed originally.