### PR TITLE
issue #126

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewStudySubject.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewStudySubject.jsp
@@ -88,24 +88,6 @@
 <jsp:useBean scope="request" id="groups" class="java.util.ArrayList"/>
 <jsp:useBean scope="request" id="from" class="java.lang.String"/>
 
-<script language="JavaScript">
-    function leftnavExpand(strLeftNavRowElementName){
-      var objLeftNavRowElement;
-
-      objLeftNavRowElement = MM_findObj(strLeftNavRowElementName);
-      if (objLeftNavRowElement != null) {
-        if (objLeftNavRowElement.style) { objLeftNavRowElement = objLeftNavRowElement.style; }
-          objLeftNavRowElement.display = (objLeftNavRowElement.display == "none" ) ? "" : "none";
-          objExCl = MM_findObj("excl_"+strLeftNavRowElementName);
-          if(objLeftNavRowElement.display == "none"){
-              objExCl.src = "images/bt_Expand.gif";
-          }else{
-              objExCl.src = "images/bt_Collapse.gif";
-          }
-        }
-      }
-</script>
-
 <table border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr><td><h1><div class="title_manage"><fmt:message key="view_subject2" bundle="${resword}"/><c:out value="${studySub.label}"/></div></h1></td></tr>
 </table>


### PR DESCRIPTION
Ok, so I should have done it this way :-) and not into OpenClinica!

When in view-study-subject you can collapse the icon-info, but you can't expand it afterwards. The reason for this is the double definition of the javascript-function leftnavExpand in the jsp, which is different from the one in global_functions_javascript.js