### PR TITLE
Layout addnewsubject

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
@@ -6,6 +6,7 @@
 <fmt:setBundle basename="org.akaza.openclinica.i18n.notes" var="restext"/>
 
 <jsp:include page="../include/submit-header.jsp"/>
+<!-- start of managestudy/findSubjects.jsp -->
 
 <!-- move the alert message to the sidebar-->
 <jsp:include page="../include/sideAlert.jsp"/>
@@ -29,61 +30,60 @@
         var parameterString = createParameterStringForLimit(id);
         location.href = '${pageContext.request.contextPath}/ListStudySubjects?'+ parameterString;
     }
-
-    jQuery(document).ready(function() {
-        jQuery('#addSubject').click(function() {
-			jQuery.blockUI({ message: jQuery('#addSubjectForm'), css:{left: "300px", top:"10px" } });
-        });
-
-        jQuery('#cancel').click(function() {
-            jQuery.unblockUI();
-            return false;
-        });
-    });
+    $.noConflict();			// to avoid conflicts with prototype.js
+	jQuery(document).ready(function() {
+		// add a listener to the add subject link
+		jQuery('#addSubject').click(function() {
+			jQuery.blockUI({message: jQuery('#addSubjectForm'), css:{left: "300px", top:"10px", cursor:"default"}});
+		});
+		// add a listerner to the cancel button in submit/addNewSubjectExpressNew.jsp 
+		jQuery('#cancel').click(function() {
+			jQuery.unblockUI();
+			return false;
+		});
+		// show the overlay with the add-new-subject-dialog when there were errors with the submission
+		<c:if test="${showOverlay}">
+        	jQuery.blockUI({ message: jQuery('#addSubjectForm'), css:{left: "300px", top:"10px", cursor:"default"}});
+   		</c:if>
+	});
 </script>
 
 <!-- then instructions-->
 <tr id="sidebar_Instructions_open" style="display: none">
-    <td class="sidebar_tab">
-
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_collapse.gif" border="0" align="right" hspace="10"></a>
-
-        <b><fmt:message key="instructions" bundle="${resword}"/></b>
-
-        <div class="sidebar_tab_content">
-
-        </div>
-
-    </td>
-
+	<td class="sidebar_tab">
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_collapse.gif" class="sidebar_collapse_expand"></a>
+		<b><fmt:message key="instructions" bundle="${resword}"/></b>
+		<div class="sidebar_tab_content"></div>
+	</td>
 </tr>
+
 <tr id="sidebar_Instructions_closed" style="display: all">
-    <td class="sidebar_tab">
-
-        <a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_expand.gif" border="0" align="right" hspace="10"></a>
-
-        <b><fmt:message key="instructions" bundle="${resword}"/></b>
-
-    </td>
+	<td class="sidebar_tab">
+		<a href="javascript:leftnavExpand('sidebar_Instructions_open'); leftnavExpand('sidebar_Instructions_closed');"><img src="images/sidebar_expand.gif" class="sidebar_collapse_expand"></a>
+		<b><fmt:message key="instructions" bundle="${resword}"/></b>
+	</td>
 </tr>
+
+<!-- include study/site info -->
 <jsp:include page="../include/sideInfo.jsp"/>
 
 <jsp:useBean scope='session' id='userBean' class='org.akaza.openclinica.bean.login.UserAccountBean'/>
 <jsp:useBean scope='request' id='crf' class='org.akaza.openclinica.bean.admin.CRFBean'/>
 
-
 <h1><span class="title_manage"><fmt:message key="view_subjects_in" bundle="${restext}"/> <c:out value="${study.name}"/></span></h1>
 
 <div id="findSubjectsDiv">
-    <form  action="${pageContext.request.contextPath}/ListStudySubjects">
-        <input type="hidden" name="module" value="admin">
-        ${findSubjectsHtml}
-    </form>
-</div>
-<div id="addSubjectForm" style="display:none;">
-      <c:import url="../submit/addNewSubjectExpressNew.jsp">
-      </c:import>
+	<form  action="${pageContext.request.contextPath}/ListStudySubjects">
+		<input type="hidden" name="module" value="admin">
+		${findSubjectsHtml}
+	</form>
 </div>
 
-<br>
+<!-- compose the overlay to add new subject, but don't show it-->
+<div id="addSubjectForm" style="display:none;">
+	<c:import url="../submit/addNewSubjectExpressNew.jsp"></c:import>
+</div>
+
+<br />
+
 <jsp:include page="../include/footer.jsp"/>

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
@@ -1,4 +1,3 @@
-<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
@@ -5,8 +5,8 @@
 <fmt:setBundle basename="org.akaza.openclinica.i18n.words" var="resword"/>
 <fmt:setBundle basename="org.akaza.openclinica.i18n.notes" var="restext"/>
 
-
 <jsp:include page="../include/submit-header.jsp"/>
+
 <!-- move the alert message to the sidebar-->
 <jsp:include page="../include/sideAlert.jsp"/>
 
@@ -15,9 +15,7 @@
 <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
 <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
 <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa.js"></script>
-<%-- <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa-original.js"></script> --%>
 <script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery.blockUI.js"></script>
-
 <script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery-migrate-1.1.1.js"></script>
 
 <script type="text/javascript">
@@ -89,9 +87,3 @@
 
 <br>
 <jsp:include page="../include/footer.jsp"/>
-
-<script type="text/javascript">
-    <c:if test="${showOverlay}">
-        jQuery.blockUI({ message: jQuery('#addSubjectForm'), css:{left: "300px", top:"10px" } });
-    </c:if>
-</script>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
@@ -1,11 +1,3 @@
-<%--
-    User: Hamid
-  Date: May 8, 2009
-  Time: 8:29:31 PM
-  To change this template use File | Settings | File Templates.
---%>
-
-
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -17,7 +9,6 @@
 <jsp:useBean scope="session" id="study" class="org.akaza.openclinica.bean.managestudy.StudyBean" />
 <jsp:useBean scope="request" id="pageMessages" class="java.util.ArrayList" />
 <jsp:useBean scope="request" id="presetValues" class="java.util.HashMap" />
-
 <jsp:useBean scope="request" id="groups" class="java.util.ArrayList" />
 
 <c:set var="uniqueIdentifier" value="" />
@@ -73,38 +64,33 @@
 <form name="subjectForm" action="AddNewSubject" method="post">
 <input type="hidden" name="subjectOverlay" value="true">
 
-<div style="width: 500px; height: 550px; overflow: scroll; background:#FFFFFF; cursor:default">
-<table border="0" cellpadding="0" >
-    <tr style="height:10px;">
-        <td width="35%"><h3><fmt:message key="add_new_subject" bundle="${resword}"/></h3></td>
-        <td >&nbsp;</td>
-    </tr>
+<div class="tableboxcenter">
+	<h3><fmt:message key="add_new_subject" bundle="${resword}"/></h3>
+	<table class="contenttable" align="center">
+		
     <tr valign="top">
         <td class="formlabel">
             <jsp:include page="../include/showSubmitted.jsp" />
             <input type="hidden" name="addWithEvent" value="1"/>
             <fmt:message key="study_subject_ID" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                    <c:choose>
-                     <c:when test="${study.studyParameterConfig.subjectIdGeneration =='auto non-editable'}">
-                      <input onfocus="this.select()" type="text" value="<c:out value="${label}"/>" size="45" class="formfield" disabled>
-                      <input type="hidden" name="label" value="<c:out value="${label}"/>">
-                     </c:when>
-                     <c:otherwise>
-                       <input onfocus="this.select()" type="text" name="label" value="<c:out value="${label}"/>" size="50" class="formfieldXL">
-                     </c:otherwise>
-                    </c:choose>
-                    </div></td>
-                    <td>*</td>
-                </tr>
-                <tr>
-                    <td><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="label"/></jsp:include></td>
-                </tr>
-                
-            </table>
+        <td>
+			<div class="formfieldXL_BG">
+				<nobr>
+					<c:choose>
+						<c:when test="${study.studyParameterConfig.subjectIdGeneration =='auto non-editable'}">
+							<input onfocus="this.select()" type="text" value="<c:out value="${label}"/>" class="formfieldS" disabled>
+							<input type="hidden" name="label" value="<c:out value="${label}"/>">
+						</c:when>
+						<c:otherwise>
+							<input onfocus="this.select()" type="text" name="label" value="<c:out value="${label}"/>" class="formfieldS">
+						</c:otherwise>
+					</c:choose>
+				&nbsp;
+	            <span class="alert">*</span>
+            	</nobr>
+				<br />
+				<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="label"/></jsp:include>
+			</div>
         </td>
     </tr>
     <c:choose>
@@ -112,14 +98,16 @@
     <tr valign="top">
         <td class="formlabel"><fmt:message key="person_ID" bundle="${resword}"/>:</td>
         <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
+            <table>
                 <tr>
                     <td valign="top"><div class="formfieldXL_BG">
                         <input onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" size="50" class="formfieldXL">
                     </div></td>
-                    <td>*</td>
+                    <td><span class="alert">*</span></td>
                 </tr>
-                <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
+                <tr>
+                	<td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
+                </tr>
             </table>
         </td>
     </tr>
@@ -128,7 +116,7 @@
     <tr valign="top">
         <td class="formlabel"><fmt:message key="person_ID" bundle="${resword}"/>:</td>
         <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
+            <table>
                 <tr>
                     <td valign="top"><div class="formfieldXL_BG">
                         <input onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" size="50" class="formfieldXL">
@@ -153,12 +141,13 @@
             <fmt:message key="enrollment_date" bundle="${resword}"/>:
         </td>
         <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
+            <table>
                 <tr>
                     <td valign="top">
-            <!--layer-background-color:white;-->
+            
             <div class="formfieldM_BG">
                         <input onfocus="this.select()" type="text" name="enrollmentDate" size="15" value="<c:out value="${enrollmentDate}" />" class="formfieldM" id="enrollmentDateField" />
+                   </div>
                     </td>
                     <td>
                     <A HREF="#">
@@ -166,8 +155,8 @@
                         <script type="text/javascript">
                         Calendar.setup({inputField  : "enrollmentDateField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger", customPX: 300, customPY: 10 });
                         </script>
-                    </a>
-                        *
+                    </a>&nbsp;
+                        <span class="alert">*</span>
                     </td>
                 </tr>
                 <tr>
@@ -181,7 +170,7 @@
         <c:if test="${study.studyParameterConfig.genderRequired !='not used'}">
         <td class="formlabel"><fmt:message key="gender" bundle="${resword}"/>:</td>
         <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
+            <table>
                 <tr>
                     <td valign="top"><div class="formfieldS_BG">
                         <select name="gender" class="formfieldS">
@@ -205,11 +194,12 @@
                                 </c:otherwise>
                             </c:choose>
                             </select>
+					</div>
                 </td>
     <td align="left">
         <c:choose>
         <c:when test="${study.studyParameterConfig.genderRequired !='false'}">
-           <span class="formlabel">*</span>
+           <span class="alert">*</span>
         </c:when>
         </c:choose>
     </td>
@@ -228,10 +218,11 @@
     <tr valign="top">
         <td class="formlabel"><fmt:message key="date_of_birth" bundle="${resword}"/>:</td>
         <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
+            <table>
                 <tr>
                     <td valign="top"><div class="formfieldM_BG">
                         <input onfocus="this.select()" type="text" name="dob" size="15" value="<c:out value="${dob}" />" class="formfieldM" id="dobField" />
+                    </div>
                     </td>
                     <td>
                     <A HREF="#">
@@ -241,7 +232,7 @@
                         </script>
                     </a>
                     </td>
-                    <td>* </td>
+                    <td><span class="alert">*</span></td>
                 </tr>
             </table>
         </td>
@@ -255,10 +246,11 @@
     <tr valign="top">
         <td class="formlabel"><fmt:message key="year_of_birth" bundle="${resword}"/>:</td>
         <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
+            <table>
                 <tr>
                     <td valign="top"><div class="formfieldM_BG">
                         <input onfocus="this.select()" type="text" name="yob" size="15" value="<c:out value="${yob}" />" class="formfieldM" />
+                        </div>
                     </td>
                     <td>(<fmt:message key="date_format_year" bundle="${resformat}"/>) *</td>
                 </tr>
@@ -307,7 +299,7 @@
     <tr valign="top">
         <td class="formlabel"><fmt:message key="SED_2" bundle="${resword}"/>:</td>
         <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
+            <table>
                 <tr><td>
                     <div class="formfieldM_BG">
                         <select name="studyEventDefinition" class="formfieldM">
@@ -319,7 +311,7 @@
                         </select>
                     </div>
                     </td>
-                    <td><span class="formlabel">*</span></td>
+                    <td><span class="alert">*</span></td>
                 </tr>
                 <tr>
                     <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="studyEventDefinition"/></jsp:include></td>
@@ -379,7 +371,7 @@
     <tr valign="top">
         <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
         <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
+            <table>
                 <tr>
                     <td valign="top"><div class="formfieldXL_BG">
                        <input type="text" name="location"size="50" class="formfieldXL">
@@ -396,16 +388,19 @@
     </c:choose>
     <tr>
         <td colspan="2" align="center">
-        <input type="submit" name="addSubject" value="<fmt:message key="add2" bundle="${resword}"/>" class="button" />
-        &nbsp;
-        <input type="button" id="cancel" name="cancel" value="   <fmt:message key="cancel" bundle="${resword}"/>" class="button"/>
+        
 
         <div id="dvForCalander" style="width:1px; height:1px;"></div>
     </td>
     </tr>
 
 </table>
-
+	<br />
+	<input type="submit" name="addSubject" value="<fmt:message key="add2" bundle="${resword}"/>" class="button" />
+    &nbsp;
+    <input type="button" id="cancel" name="cancel" value="   <fmt:message key="cancel" bundle="${resword}"/>" class="button"/>
+	<br />
+	&nbsp;
 </div>
 
 </form>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/addNewSubjectExpressNew.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -9,6 +10,7 @@
 <jsp:useBean scope="session" id="study" class="org.akaza.openclinica.bean.managestudy.StudyBean" />
 <jsp:useBean scope="request" id="pageMessages" class="java.util.ArrayList" />
 <jsp:useBean scope="request" id="presetValues" class="java.util.HashMap" />
+
 <jsp:useBean scope="request" id="groups" class="java.util.ArrayList" />
 
 <c:set var="uniqueIdentifier" value="" />
@@ -60,347 +62,284 @@
 	</c:if>
 </c:forEach>
 
-
+<!-- start of submit/addNewSubjectExpressNew.jsp -->
 <form name="subjectForm" action="AddNewSubject" method="post">
 <input type="hidden" name="subjectOverlay" value="true">
 
-<div class="tableboxcenter">
-	<h3><fmt:message key="add_new_subject" bundle="${resword}"/></h3>
-	<table class="contenttable" align="center">
-		
-    <tr valign="top">
-        <td class="formlabel">
-            <jsp:include page="../include/showSubmitted.jsp" />
-            <input type="hidden" name="addWithEvent" value="1"/>
-            <fmt:message key="study_subject_ID" bundle="${resword}"/>:</td>
-        <td>
-			<div class="formfieldXL_BG">
-				<nobr>
+<div align="center">
+	<h1><span class="title_manage"><fmt:message key="add_new_subject" bundle="${resword}"/></span></h1>
+	<table class="contenttable">
+    	<tr>
+        	<td class="formlabel">
+				<jsp:include page="../include/showSubmitted.jsp" />
+				<input type="hidden" name="addWithEvent" value="1"/>
+				<fmt:message key="study_subject_ID" bundle="${resword}"/>:
+			</td>
+			<td>
+				<div class="formfieldXL_BG">
 					<c:choose>
 						<c:when test="${study.studyParameterConfig.subjectIdGeneration =='auto non-editable'}">
-							<input onfocus="this.select()" type="text" value="<c:out value="${label}"/>" class="formfieldS" disabled>
+							<input onfocus="this.select()" type="text" value="<c:out value="${label}"/>" class="formfieldL" disabled>
 							<input type="hidden" name="label" value="<c:out value="${label}"/>">
 						</c:when>
 						<c:otherwise>
-							<input onfocus="this.select()" type="text" name="label" value="<c:out value="${label}"/>" class="formfieldS">
+							<input onfocus="this.select()" type="text" name="label" value="<c:out value="${label}"/>" class="formfieldL">&nbsp;
 						</c:otherwise>
 					</c:choose>
-				&nbsp;
-	            <span class="alert">*</span>
-            	</nobr>
+					<span class="alert">*</span>
+					<br />
+					<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="label"/></jsp:include>
+				</div>
+			</td>
+		</tr>
+    
+<c:choose>
+	<c:when test="${study.studyParameterConfig.subjectPersonIdRequired =='required'}">
+		<tr>
+			<td class="formlabel">
+				<fmt:message key="person_ID" bundle="${resword}"/>:
+			</td>
+			<td>
+				<div class="formfieldXL_BG">
+				<input onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" class="formfieldL">&nbsp;
+				<span class="alert">*</span>
 				<br />
-				<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="label"/></jsp:include>
-			</div>
-        </td>
-    </tr>
-    <c:choose>
-    <c:when test="${study.studyParameterConfig.subjectPersonIdRequired =='required'}">
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="person_ID" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table>
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                        <input onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" size="50" class="formfieldXL">
-                    </div></td>
-                    <td><span class="alert">*</span></td>
-                </tr>
-                <tr>
-                	<td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
-                </tr>
-            </table>
-        </td>
-    </tr>
+				<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include>
+				</div>
+			</td>
+	    </tr>
     </c:when>
     <c:when test="${study.studyParameterConfig.subjectPersonIdRequired =='optional'}">
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="person_ID" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table>
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                        <input onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" size="50" class="formfieldXL">
-                    </div></td>
-                    <td>&nbsp;</td>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include></td>
-                </tr>
-            </table>
-        </td>
-    </tr>
+		<tr>
+			<td class="formlabel">
+				<fmt:message key="person_ID" bundle="${resword}"/>:
+	        </td>
+			<td>
+				<div class="formfieldXL_BG">
+				<input onfocus="this.select()" type="text" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>" class="formfieldL">&nbsp;
+				<br />
+				<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="uniqueIdentifier"/></jsp:include>
+				</div>
+			</td>
+	    </tr>
     </c:when>
     <c:otherwise>
-      <input type="hidden" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>">
+		<input type="hidden" name="uniqueIdentifier" value="<c:out value="${uniqueIdentifier}"/>">
     </c:otherwise>
-    </c:choose>
+</c:choose>
 
-    <tr valign="top">
-
+    <tr>
         <td class="formlabel">
             <fmt:message key="enrollment_date" bundle="${resword}"/>:
         </td>
-        <td valign="top">
-            <table>
-                <tr>
-                    <td valign="top">
-            
-            <div class="formfieldM_BG">
-                        <input onfocus="this.select()" type="text" name="enrollmentDate" size="15" value="<c:out value="${enrollmentDate}" />" class="formfieldM" id="enrollmentDateField" />
-                   </div>
-                    </td>
-                    <td>
-                    <A HREF="#">
-                      <img src="images/bt_Calendar.gif" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger" />
-                        <script type="text/javascript">
-                        Calendar.setup({inputField  : "enrollmentDateField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger", customPX: 300, customPY: 10 });
-                        </script>
-                    </a>&nbsp;
-                        <span class="alert">*</span>
-                    </td>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="enrollmentDate"/></jsp:include></td>
-                </tr>
-            </table>
+        <td>
+			<div class="formfieldM_BG">
+	            <input onfocus="this.select()" type="text" name="enrollmentDate" value="<c:out value="${enrollmentDate}" />" class="formfieldM" id="enrollmentDateField" />&nbsp;		
+				<a href="#">
+					<img src="images/bt_Calendar.gif" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger" />
+					<script type="text/javascript">Calendar.setup({inputField  : "enrollmentDateField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger", customPX: 300, customPY: 10 }); </script>
+				</a>&nbsp;
+				<span class="alert">*</span>
+				<br />
+				<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="enrollmentDate"/></jsp:include>
+			</div>
         </td>
     </tr>
+    
+<c:if test="${study.studyParameterConfig.genderRequired !='not used'}">
+	<tr>
+		<td class="formlabel">
+			<fmt:message key="gender" bundle="${resword}"/>:
+		</td>
+		<td>
+			<div class="formfieldS_BG">
+				<select name="gender" class="formfieldS">
+		        	<option value="">-<fmt:message key="select" bundle="${resword}"/>-</option>
+		            <c:choose>
+		            	<c:when test="${!empty chosenGender}">
+							<c:choose>
+								<c:when test='${chosenGender == "m"}'>
+									<option value="m" selected><fmt:message key="male" bundle="${resword}"/></option>
+									<option value="f"><fmt:message key="female" bundle="${resword}"/></option>
+								</c:when>
+								<c:otherwise>
+									<option value="m"><fmt:message key="male" bundle="${resword}"/></option>
+									<option value="f" selected><fmt:message key="female" bundle="${resword}"/></option>
+								</c:otherwise>
+							</c:choose>
+		                </c:when>
+		                <c:otherwise>
+		                                    <option value="m"><fmt:message key="male" bundle="${resword}"/></option>
+		                                    <option value="f"><fmt:message key="female" bundle="${resword}"/></option>
+		                </c:otherwise>
+					</c:choose>
+				</select>&nbsp;
+				<c:choose>
+					<c:when test="${study.studyParameterConfig.genderRequired !='false'}">
+						<span class="alert">*</span>
+					</c:when>
+				</c:choose>
+				<br />
+				<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="gender"/></jsp:include>
+			</div>
+		</td>   
+	</tr>
+</c:if>
 
-    <tr valign="top">
-        <c:if test="${study.studyParameterConfig.genderRequired !='not used'}">
-        <td class="formlabel"><fmt:message key="gender" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table>
-                <tr>
-                    <td valign="top"><div class="formfieldS_BG">
-                        <select name="gender" class="formfieldS">
-                            <option value="">-<fmt:message key="select" bundle="${resword}"/>-</option>
-                            <c:choose>
-                                <c:when test="${!empty chosenGender}">
-                                    <c:choose>
-                                        <c:when test='${chosenGender == "m"}'>
-                                            <option value="m" selected><fmt:message key="male" bundle="${resword}"/></option>
-                                            <option value="f"><fmt:message key="female" bundle="${resword}"/></option>
-                                        </c:when>
-                                        <c:otherwise>
-                                            <option value="m"><fmt:message key="male" bundle="${resword}"/></option>
-                                            <option value="f" selected><fmt:message key="female" bundle="${resword}"/></option>
-                                        </c:otherwise>
-                                    </c:choose>
-                                </c:when>
-                                <c:otherwise>
-                                    <option value="m"><fmt:message key="male" bundle="${resword}"/></option>
-                                    <option value="f"><fmt:message key="female" bundle="${resword}"/></option>
-                                </c:otherwise>
-                            </c:choose>
-                            </select>
-					</div>
-                </td>
-    <td align="left">
-        <c:choose>
-        <c:when test="${study.studyParameterConfig.genderRequired !='false'}">
-           <span class="alert">*</span>
-        </c:when>
-        </c:choose>
-    </td>
-    </tr>
-    </table>
-        </td>
-    </c:if>
-    </tr>
+<c:choose>
+	<c:when test="${study.studyParameterConfig.collectDob == '1'}">
     <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="gender"/></jsp:include></td>
-    </tr>
-
-
-    <c:choose>
-    <c:when test="${study.studyParameterConfig.collectDob == '1'}">
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="date_of_birth" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table>
-                <tr>
-                    <td valign="top"><div class="formfieldM_BG">
-                        <input onfocus="this.select()" type="text" name="dob" size="15" value="<c:out value="${dob}" />" class="formfieldM" id="dobField" />
-                    </div>
-                    </td>
-                    <td>
-                    <A HREF="#">
-                      <img src="images/bt_Calendar.gif" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="dobTrigger" />
-                        <script type="text/javascript">
+        <td class="formlabel">
+        	<fmt:message key="date_of_birth" bundle="${resword}"/>:
+        </td>
+        <td>
+        	<div class="formfieldM_BG">
+            	<input onfocus="this.select()" type="text" name="dob" value="<c:out value="${dob}" />" class="formfieldM" id="dobField" />
+				<a href="#">
+                    <img src="images/bt_Calendar.gif" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="dobTrigger" />
+					<script type="text/javascript">
                         Calendar.setup({inputField  : "dobField", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "dobTrigger", customPX: 300, customPY: 10 });
-                        </script>
-                    </a>
-                    </td>
-                    <td><span class="alert">*</span></td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="dob"/></jsp:include></td>
-    </tr>
-
-    </c:when>
+					</script>
+				</a>&nbsp;
+				<span class="alert">* </span>
+			</div>
+			<br />
+			<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="dob"/></jsp:include>
+		</td>
+	</tr>
+	</c:when>
     <c:when test="${study.studyParameterConfig.collectDob == '2'}">
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="year_of_birth" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table>
-                <tr>
-                    <td valign="top"><div class="formfieldM_BG">
-                        <input onfocus="this.select()" type="text" name="yob" size="15" value="<c:out value="${yob}" />" class="formfieldM" />
-                        </div>
-                    </td>
-                    <td>(<fmt:message key="date_format_year" bundle="${resformat}"/>) *</td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="yob"/></jsp:include></td>
-    </tr>
+		<tr>
+        	<td class="formlabel">
+        		<fmt:message key="year_of_birth" bundle="${resword}"/>:
+	        </td>
+	        <td>
+	        	<div class="formfieldM_BG">
+		        	<input onfocus="this.select()" type="text" name="yob" value="<c:out value="${yob}" />" class="formfieldM" />&nbsp;
+					(<fmt:message key="date_format_year" bundle="${resformat}"/>)&nbsp; 
+					<span class="alert">*</span>
+					<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="yob"/></jsp:include>
+				</div>
+			</td>
+		</tr>
+	</c:when>
+	<c:otherwise>
+    	<input type="hidden" name="dob" value="" />
+	</c:otherwise>
+</c:choose>
 
-  </c:when>
-  <c:otherwise>
-    <input type="hidden" name="dob" value="" />
-  </c:otherwise>
- </c:choose>
 <c:if test="${(!empty studyGroupClasses)}">
-    <tr valign="top">
-      <td class="formlabel"><fmt:message key="subject_group_class" bundle="${resword}"/>:
-      <td class="table_cell">
-      <c:set var="count" value="0"/>
-      <table border="0" cellpadding="0">
-        <c:forEach var="group" items="${studyGroupClasses}">
-        <tr valign="top">
-         <td><b><c:out value="${group.name}"/></b></td>
-         <td><div class="formfieldM_BG">
-             <select name="studyGroupId<c:out value="${count}"/>" class="formfieldM">
-                 <option value=""><c:out value="${group.name}"/>:</option>
-                  <c:forEach var="studyGroup" items="${group.studyGroups}">
-                    <option value="<c:out value="${studyGroup.id}"/>"><c:out value="${studyGroup.name}"/></option>
-                  </c:forEach>
-              </select></div>
-             <c:import url="../showMessage.jsp"><c:param name="key" value="studyGroupId${count}" /></c:import>
-
-              </td>
-              <c:if test="${group.subjectAssignment=='Required'}">
-                <td align="left">*</td>
-              </c:if>
-              </tr>
-             <c:set var="count" value="${count+1}"/>
-        </c:forEach>
-        </table>
-      </td>
+	<tr>
+		<td class="formlabel">
+			<fmt:message key="subject_group_class" bundle="${resword}"/>:
+		</td>
+      	<td>
+      		<div class="formfieldM_BG">
+				<c:set var="count" value="0"/>
+				<c:forEach var="group" items="${studyGroupClasses}">
+					<c:out value="${group.name}"/>&nbsp;
+             		<select name="studyGroupId<c:out value="${count}"/>" class="formfieldM">
+						<option value=""><c:out value="${group.name}"/>:</option>
+							<c:forEach var="studyGroup" items="${group.studyGroups}">
+								<option value="<c:out value="${studyGroup.id}"/>"><c:out value="${studyGroup.name}"/></option>
+							</c:forEach>
+					</select>&nbsp;
+					<c:if test="${group.subjectAssignment=='Required'}">
+						<span class="alert">*</span>
+					</c:if>
+              		<br />
+					<c:import url="../showMessage.jsp"><c:param name="key" value="studyGroupId${count}" /></c:import>
+             		<c:set var="count" value="${count+1}"/>
+				</c:forEach>
+			</div>
+		</td>
     </tr>
 </c:if>
 
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="SED_2" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table>
-                <tr><td>
-                    <div class="formfieldM_BG">
-                        <select name="studyEventDefinition" class="formfieldM">
-                            <option value="">-<fmt:message key="select" bundle="${resword}"/>-</option>
-                            <c:forEach var="event" items="${allDefsArray}">
-                                <option <c:if test="${studyEventDefinition == event.id}">SELECTED</c:if> value="<c:out value="${event.id}"/>"><c:out value="${event.name}" />
-                                </option>
-                            </c:forEach>
-                        </select>
-                    </div>
-                    </td>
-                    <td><span class="alert">*</span></td>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="studyEventDefinition"/></jsp:include></td>
-                </tr>
-
-            </table>
+	<tr>
+		<td class="formlabel">
+			<fmt:message key="SED_2" bundle="${resword}"/>:
+		</td>
+		<td>
+			<div class="formfieldM_BG">
+	            <select name="studyEventDefinition" class="formfieldM">
+	                <option value="">-<fmt:message key="select" bundle="${resword}"/>-</option>
+	                <c:forEach var="event" items="${allDefsArray}">
+	                    <option <c:if test="${studyEventDefinition == event.id}">SELECTED</c:if> value="<c:out value="${event.id}"/>"><c:out value="${event.name}" />
+	                    </option>
+	                </c:forEach>
+	            </select>&nbsp;
+				<span class="alert">*</span>
+				<br />
+				<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="studyEventDefinition"/></jsp:include>
+			</div>
         </td>
     </tr>
 
-    <tr valign="top">
-        <td class="formlabel">
+	<tr>
+		<td class="formlabel">
             <fmt:message key="start_date" bundle="${resword}"/>:
         </td>
-          <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top">
-                        <div class="formfieldM_BG">
-                        <input type="text" name="startDate" size="15" value="<c:out value="${startDate}" />" class="formfieldM" id="enrollmentDateField2" />
-                    </td>
-                    <td>
-                        <A HREF="#" >
-                         <img src="images/bt_Calendar.gif" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger2"/></a>*
-                         <script type="text/javascript">
-                         Calendar.setup({inputField  : "enrollmentDateField2", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger2" ,customPX: 300, customPY: 10 });
-                         </script>
-                    </td>
-                </tr>
-                <tr>
-                    <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="startDate"/></jsp:include></td>
-                </tr>
+        <td>
+        	<div class="formfieldM_BG">
+				<input type="text" name="startDate" value="<c:out value="${startDate}" />" class="formfieldM" id="enrollmentDateField2" />
+				<a href="#" >
+                	<img src="images/bt_Calendar.gif" alt="<fmt:message key="show_calendar" bundle="${resword}"/>" title="<fmt:message key="show_calendar" bundle="${resword}"/>" border="0" id="enrollmentDateTrigger2"/>
+                </a>
+                <script type="text/javascript">
+                	Calendar.setup({inputField  : "enrollmentDateField2", ifFormat    : "<fmt:message key="date_format_calender" bundle="${resformat}"/>", button      : "enrollmentDateTrigger2" ,customPX: 300, customPY: 10 });
+				</script>
+                &nbsp;
+				<span class="alert">*</span>
+				<br />
+				<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="startDate"/></jsp:include>
+			</div>
+		</td>
+	</tr>
 
-            </table>
-          </td>
-    </tr>
-    <c:choose>
-    <c:when test="${study.studyParameterConfig.eventLocationRequired == 'required'}">
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                       <input type="text" name="location"size="50" value="<c:out value="${location}"/>" class="formfieldXL">
-                    </div></td>
-                    <td>*</td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2"><jsp:include page="../showMessage.jsp"><jsp:param name="key" value="location"/></jsp:include></td>
-    </tr>
-
+<c:choose>
+	<c:when test="${study.studyParameterConfig.eventLocationRequired == 'required'}">
+		<tr>
+        	<td class="formlabel">
+        		<fmt:message key="location" bundle="${resword}"/>:
+        	</td>
+			<td>
+				<div class="formfieldXL_BG">
+	                <input type="text" name="location" value="<c:out value="${location}"/>" class="formfieldXL">&nbsp;
+					<span class="alert">*</span>
+					<br />
+					<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="location"/></jsp:include>
+				</div>
+			</td>
+		</tr>
     </c:when>
     <c:when test="${study.studyParameterConfig.eventLocationRequired == 'optional'}">
-    <tr valign="top">
-        <td class="formlabel"><fmt:message key="location" bundle="${resword}"/>:</td>
-        <td valign="top">
-            <table>
-                <tr>
-                    <td valign="top"><div class="formfieldXL_BG">
-                       <input type="text" name="location"size="50" class="formfieldXL">
-                    </div></td>
-                    <td>&nbsp;</td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-    </c:when>
+		<tr>
+        	<td class="formlabel">
+        		<fmt:message key="location" bundle="${resword}"/>:
+        	</td>
+			<td>
+				<div class="formfieldXL_BG">
+	                <input type="text" name="location" value="<c:out value="${location}"/>" class="formfieldXL">&nbsp;
+					<br />
+					<jsp:include page="../showMessage.jsp"><jsp:param name="key" value="location"/></jsp:include>
+				</div>
+			</td>
+		</tr>
+	</c:when>
     <c:otherwise>
-        <input type="hidden" name="location" value=""/>
+		<input type="hidden" name="location" value=""/>
     </c:otherwise>
-    </c:choose>
-    <tr>
-        <td colspan="2" align="center">
-        
+</c:choose>    
 
-        <div id="dvForCalander" style="width:1px; height:1px;"></div>
-    </td>
-    </tr>
+	
 
 </table>
-	<br />
-	<input type="submit" name="addSubject" value="<fmt:message key="add2" bundle="${resword}"/>" class="button" />
-    &nbsp;
-    <input type="button" id="cancel" name="cancel" value="   <fmt:message key="cancel" bundle="${resword}"/>" class="button"/>
-	<br />
-	&nbsp;
+&nbsp;<br />
+<div id="dvForCalander" style="width:1px; height:1px;"></div>
+	<input type="submit" name="addSubject" value="<fmt:message key="add2" bundle="${resword}"/>" class="button" /> &nbsp;
+	<input type="button" id="cancel" name="cancel" value="   <fmt:message key="cancel" bundle="${resword}"/>" class="button"/>
 </div>
-
+<br />&nbsp;
 </form>
+<!-- end of submit/addNewSubjectExpressNew.jsp -->


### PR DESCRIPTION
Closes #374 and #375 
Main change is in findSubjects when calling blockUI paassing extra parameter cursor:"default". Plus moved the block that is applicable to the situation where a submission generated errors from the bottom of the page to the jQuery(document).ready part.
In addNewSubjectExpressNew all tables in tables were removed and one outer table was left with br as a way to start a new line.