### PR TITLE
Remove link from unsupported rule designer

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/submit/ViewRuleAssignmentTableFactory.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ViewRuleAssignmentTableFactory.java
@@ -810,11 +810,8 @@ public class ViewRuleAssignmentTableFactory extends AbstractTableFactory {
             String runTime = (String) ((HashMap<Object, Object>) item).get("ruleSetRunTime");
             List<RuleActionBean> actions = (List<RuleActionBean>) ((HashMap<Object, Object>) item).get("theActions");
             String message = actions.get(0).getSummary();
-        //    if (isDesignerRequest)
-          //  {
-                value += testEditByDesignerBuilder(target, ruleOid, runTime, message);
-            //} else
-                if (ruleSetRule.getStatus() != Status.DELETED) {
+            
+            if (ruleSetRule.getStatus() != Status.DELETED) {
                 value +=
                     viewLinkBuilder(ruleSetId) + executeLinkBuilder(ruleSetId, ruleId , target) + removeLinkBuilder(ruleSetRuleId, ruleSetId)
                         + extractXmlLinkBuilder(ruleSetRuleId) + testLinkBuilder(ruleSetRuleId);
@@ -927,20 +924,6 @@ public class ViewRuleAssignmentTableFactory extends AbstractTableFactory {
         actionLink.append("onMouseDown=\"javascript:setImage('bt_test','images/bt_EnterData_d.gif');\"");
         actionLink.append("onMouseUp=\"javascript:setImage('bt_test','images/bt_Reassign_d.gif');\"").close();
         actionLink.img().name("bt_test").src("images/bt_Reassign_d.gif").border("0").alt("Test").title("Test").append("hspace=\"2\"").end().aEnd();
-        actionLink.append("&nbsp;&nbsp;&nbsp;");
-        return actionLink.toString();
-
-    }
-
-    private String testEditByDesignerBuilder(String target, String ruleOid, String runTime, String message) {
-        HtmlBuilder actionLink = new HtmlBuilder();
-        // String designerURL = "http://localhost:8080/Designer-0.1.0.BUILD-SNAPSHOT/";
-        setDesignerLink(designerURL  + "&target=" + target + "&ruleOid=" + ruleOid +"&study_oid=" +currentStudy.getOid()+"&provider_user="+getCurrentUser().getName());
-        actionLink.a().href(designerURL  + "&target=" + target + "&ruleOid=" + ruleOid +"&study_oid=" +currentStudy.getOid()+"&provider_user="+getCurrentUser().getName()+"&path=ViewRuleAssignment&runTime="+ runTime +"&msg="+ convertMessage(message));
-        actionLink.append("target=\"_parent\"");
-        actionLink.append("onMouseDown=\"javascript:setImage('bt_test','images/bt_EnterData_d.gif');\"");
-        actionLink.append("onMouseUp=\"javascript:setImage('bt_test','images/bt_EnterData.gif');\"").close();
-        actionLink.img().name("bt_test").src("images/bt_EnterData.gif").border("0").alt("Rule Designer").title("Rule Designer").append("hspace=\"2\"").end().aEnd();
         actionLink.append("&nbsp;&nbsp;&nbsp;");
         return actionLink.toString();
 

--- a/web/src/main/webapp/WEB-INF/jsp/studymodule.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/studymodule.jsp
@@ -402,22 +402,18 @@
             <td>
                 <c:url var="createRule" value="/ImportRule"/>
                 <c:url var="viewRule" value="/ViewRuleAssignment"/>
-				<c:url var="ruleDesignerURL" value="${ruleDesignerURL}"/>
 
                 <c:choose>
                     <c:when test="${studyModuleStatus.rule == 1}">
                         <a href="${createRule}"><img src="../images/create_new.gif" border="0" alt="<fmt:message key="add2" bundle="${resword}"/>" title="<fmt:message key="add2" bundle="${resword}"/>"/></a>
-						<a href="${ruleDesignerURL}access?host=${hostPath}&app=${contextPath}&study_oid=${study.oid}&provider_user=${userBean.name}&path=${path}"><img src="../images/bt_EnterData.gif" border="0" alt="<fmt:message key="rule_designer" bundle="${resword}"/>" title="<fmt:message key="rule_designer" bundle="${resword}"/>"/></a>
                     </c:when>
                     <c:when test="${studyModuleStatus.rule == 2}">
                         <a href="${viewRule}"><img src="../images/bt_Details.gif" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>"/></a>
                         <a href="${createRule}"><img src="../images/create_new.gif" border="0" alt="<fmt:message key="add2" bundle="${resword}"/>" title="<fmt:message key="add2" bundle="${resword}"/>"/></a>
-						<a href="${ruleDesignerURL}access?host=${hostPath}&app=${contextPath}&study_oid=${study.oid}&provider_user=${userBean.name}&path=${path}"><img src="../images/bt_EnterData.gif" border="0" alt="<fmt:message key="rule_designer" bundle="${resword}"/>" title="<fmt:message key="rule_designer" bundle="${resword}"/>"/></a>
                     </c:when>
                     <c:otherwise>
                         <a href="${viewRule}"><img src="../images/bt_Details.gif" border="0" alt="<fmt:message key="view" bundle="${resword}"/>" title="<fmt:message key="view" bundle="${resword}"/>"/></a>
                         <a href="${createRule}"><img src="../images/create_new.gif" border="0" alt="<fmt:message key="add2" bundle="${resword}"/>" title="<fmt:message key="add2" bundle="${resword}"/>"/></a>
-						<a href="${ruleDesignerURL}access?host=${hostPath}&app=${contextPath}&study_oid=${study.oid}&provider_user=${userBean.name}&path=${path}"><img src="../images/bt_EnterData.gif" border="0" alt="<fmt:message key="rule_designer" bundle="${resword}"/>" title="<fmt:message key="rule_designer" bundle="${resword}"/>"/></a>
                     </c:otherwise>
                 </c:choose>
             </td>

--- a/web/src/main/webapp/WEB-INF/jsp/submit/importRules.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/importRules.jsp
@@ -91,12 +91,6 @@
 <!--<div class="homebox_bullets"><a href="ImportRule?action=downloadtemplateWithNotes"><fmt:message key="rule_import_all_actions_with_notes" bundle="${resterm}"/></a></div><br/> -->
 <div class="homebox_bullets"><a href="ImportRule?action=downloadtemplate"><fmt:message key="rule_import_all_actions_without_notes" bundle="${resterm}"/></a></div><br/>
 
-<!-- @pgawade 13-April-2011 - Fix for issue #8877: Removed the Rule Designer link from import Rule Data page
-as the link is provided on Build Study page tasks -> Create Rules -> Actions  
-<span class="table_title_Admin">Build Rules</span>
-<div>&nbsp;</div>
-<div class="homebox_bullets"><a href="${designerURL}access?host=${hostPath}&app=${contextPath}&study_oid=${study.oid}&provider_user=${userBean.name}">Designer</a></div><br/>
--->
 <c:choose>
     <c:when test="${userBean.sysAdmin && module=='admin'}">
         <c:import url="../include/workflow.jsp">

--- a/web/src/main/webapp/WEB-INF/jsp/submit/viewRules.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/submit/viewRules.jsp
@@ -203,12 +203,6 @@
          href="TestRule?ruleSetRuleId=<c:out value='${ruleSetRule.id}'/>&ruleSetId=<c:out value="${ruleSet.id}"/>"><img align="left" hspace="6" border="0" title="Test" alt="Test" src="images/bt_Reassign_d.gif" name="Test"></a>
       
       </td>
-
-     <td>
-      <a onmouseup="javascript:setImage('bt_run','images/bt_EnterData.gif');" 
-         onmousedown="javascript:setImage('bt_run','images/bt_EnterData_d.gif');" 
-         href="${designerUrl}&target=${ruleSet.target.value}&ruleOid=${ruleSetRule.ruleBean.oid}&study_oid=${currentStudy}&provider_user=${providerUser}&path=ViewRuleSet?ruleSetId=${ruleSet.id}"><img align="left" hspace="6" border="0" title="Rule Designer" alt="Rule Designer" src="images/bt_EnterData.gif" name="Test"></a>
-      </td>
       <%--</c:when>--%>
       <%--<c:otherwise>--%>
       <%--</c:otherwise>--%>


### PR DESCRIPTION
Even if configured the link to rule designer will not be shown anymore because we do not support it anyway as the oauth endpoint was removed in the past and there is no interest in maintaining extra designer application.