### PR TITLE
Re-introduce external randomization delegation (opt-in, #39-safe)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -154,6 +154,23 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
+		<!-- Required by the randomization feature (RandomizeService uses
+		     JsonNode/ObjectMapper to parse the external service's REST
+		     responses). -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<!-- Required by the randomization feature: RandomizeService uses
+		     org.apache.http.ssl.SSLContextBuilder (httpcore) to build an
+		     SSL-skipping request factory for the external randomization
+		     endpoint. httpcore is
+		     otherwise only present transitively via httpclient. -->
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>4.4.11</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-ldap</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -161,16 +161,6 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-		<!-- Required by the randomization feature: RandomizeService uses
-		     org.apache.http.ssl.SSLContextBuilder (httpcore) to build an
-		     SSL-skipping request factory for the external randomization
-		     endpoint. httpcore is
-		     otherwise only present transitively via httpclient. -->
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore</artifactId>
-			<version>4.4.11</version>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-ldap</artifactId>

--- a/core/src/main/filters/datainfo.properties
+++ b/core/src/main/filters/datainfo.properties
@@ -110,19 +110,6 @@ mailErrorMsg=developers@openclinica.org
 sysURL=http://localhost:8080/${WEBAPP}/MainMenu
 
 #############################################################################
-# 8b - moduleManager
-#
-# Base URL of the external randomization module. Used by the
-# randomization feature to fetch the per-study allocation configuration
-# (/app/rest/oc/se_randomizations) and to perform allocation requests.
-# Leave empty to disable randomization requests: the feature degrades
-# gracefully and the application starts normally when this is unset.
-#
-# OPTIONAL
-#############################################################################
-moduleManager=
-
-#############################################################################
 # 9 - max_inactive_interval
 #
 # This is maximum time interval between client requests. That is,
@@ -378,3 +365,16 @@ ldap.userData.organization=company
 # and displays a "Manual Download" section within "Tasks" menu. Valid
 # values: [true|false(default)]. 
 display.manual=false
+
+#############################################################################
+# 25 - moduleManager
+#
+# Base URL of the external randomization module. Used by the
+# randomization feature to fetch the per-study allocation configuration
+# (/app/rest/oc/se_randomizations) and to perform allocation requests.
+# Leave empty to disable randomization requests: the feature degrades
+# gracefully and the application starts normally when this is unset.
+#
+# OPTIONAL
+#############################################################################
+moduleManager=

--- a/core/src/main/filters/datainfo.properties
+++ b/core/src/main/filters/datainfo.properties
@@ -110,6 +110,19 @@ mailErrorMsg=developers@openclinica.org
 sysURL=http://localhost:8080/${WEBAPP}/MainMenu
 
 #############################################################################
+# 8b - moduleManager
+#
+# Base URL of the external randomization module. Used by the
+# randomization feature to fetch the per-study allocation configuration
+# (/app/rest/oc/se_randomizations) and to perform allocation requests.
+# Leave empty to disable randomization requests: the feature degrades
+# gracefully and the application starts normally when this is unset.
+#
+# OPTIONAL
+#############################################################################
+moduleManager=
+
+#############################################################################
 # 9 - max_inactive_interval
 #
 # This is maximum time interval between client requests. That is,

--- a/core/src/main/java/org/akaza/openclinica/domain/rule/action/ActionProcessorFacade.java
+++ b/core/src/main/java/org/akaza/openclinica/domain/rule/action/ActionProcessorFacade.java
@@ -1,8 +1,8 @@
 /*
  * LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
- * For details see: https://www.libreclinica.org/download.html#headLicense
- *
+
+ * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
  * copyright (C) 2020 - 2026 LibreClinica

--- a/core/src/main/java/org/akaza/openclinica/domain/rule/action/ActionProcessorFacade.java
+++ b/core/src/main/java/org/akaza/openclinica/domain/rule/action/ActionProcessorFacade.java
@@ -1,11 +1,30 @@
 /*
  * LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
-
- * For details see: https://libreclinica.org/license
+ * For details see: https://www.libreclinica.org/download.html#headLicense
+ *
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
- * copyright (C) 2020 - 2024 LibreClinica
+ * copyright (C) 2020 - 2026 LibreClinica
+ * copyright (C) 2026 UMIN (University Hospital Medical Information Network)
+ *
+ * Author:  Yoshiteru Chiba
+ * Notice:  Developed under a service-agreement contract with UMIN;
+ *          copyright in this modification has been assigned to UMIN. The
+ *          author retains moral rights inalienable under Article 59
+ *          of the Japanese Copyright Act. See README for full
+ *          attribution.
+ *
+ * Modifications:
+ *   - RANDOMIZE case: restored dispatch to RandomizeActionProcessor
+ *     (the LibreClinica fork had stubbed this case to throw
+ *     "not supported"); date: 2026-03-11 - 2026-03-12.
+ *
+ * License selection:
+ *   The OpenClinica original was licensed under LGPL v2.1 or later.
+ *   Per LGPL v2.1 section 13, this work selects version 3.0 of the GNU
+ *   Lesser General Public License, matching the upstream LibreClinica
+ *   distribution license.
  */
 package org.akaza.openclinica.domain.rule.action;
 
@@ -37,8 +56,7 @@ public class ActionProcessorFacade {
         case INSERT:
             return new InsertActionProcessor(ds, itemMetadataService, ruleActionRunLogDao, ruleSet, ruleSetRule);
         case RANDOMIZE:
-            // Randomization is removed from LibreClinica
-            throw new OpenClinicaSystemException("actionType", "action type 'RANDOMIZE' is not supported in LibreClinica!");
+            return new RandomizeActionProcessor(ds, itemMetadataService, ruleActionRunLogDao, ruleSet, ruleSetRule);
         default:
             throw new OpenClinicaSystemException("actionType", "Unrecognized action type!");
         }

--- a/core/src/main/java/org/akaza/openclinica/domain/rule/action/RandomizeActionProcessor.java
+++ b/core/src/main/java/org/akaza/openclinica/domain/rule/action/RandomizeActionProcessor.java
@@ -1,8 +1,8 @@
 /*
  * LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
- * For details see: https://www.libreclinica.org/download.html#headLicense
- *
+
+ * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
  * copyright (C) 2020 - 2026 LibreClinica

--- a/core/src/main/java/org/akaza/openclinica/domain/rule/action/RandomizeActionProcessor.java
+++ b/core/src/main/java/org/akaza/openclinica/domain/rule/action/RandomizeActionProcessor.java
@@ -1,0 +1,165 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+ * For details see: https://www.libreclinica.org/download.html#headLicense
+ *
+ * copyright (C) 2003 - 2011 Akaza Research
+ * copyright (C) 2003 - 2019 OpenClinica
+ * copyright (C) 2020 - 2026 LibreClinica
+ * copyright (C) 2026 UMIN (University Hospital Medical Information Network)
+ *
+ * Author:  Yoshiteru Chiba
+ * Notice:  Developed under a service-agreement contract with UMIN;
+ *          copyright in this port has been assigned to UMIN. The
+ *          author retains moral rights inalienable under Article 59
+ *          of the Japanese Copyright Act. See README for full
+ *          attribution.
+ *
+ * Modifications:
+ *   - Ported from OpenClinica v3.x; date: 2026-03-11 - 2026-03-12.
+ *   - Source content compatible as-is with LibreClinica
+ *     (OpenClinica source does not reference SAVE_AND_GO_NEXT).
+ *
+ * License selection:
+ *   The OpenClinica original was licensed under LGPL v2.1 or later.
+ *   Per LGPL v2.1 section 13, this work selects version 3.0 of the GNU
+ *   Lesser General Public License, matching the upstream LibreClinica
+ *   distribution license.
+ */
+package org.akaza.openclinica.domain.rule.action;
+
+import org.akaza.openclinica.bean.core.Status;
+import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.bean.managestudy.StudyBean;
+import org.akaza.openclinica.bean.service.StudyParameterValueBean;
+import org.akaza.openclinica.bean.submit.ItemDataBean;
+import org.akaza.openclinica.dao.hibernate.RuleActionRunLogDao;
+import org.akaza.openclinica.dao.managestudy.StudyDAO;
+import org.akaza.openclinica.dao.service.StudyParameterValueDAO;
+import org.akaza.openclinica.domain.rule.RuleSetBean;
+import org.akaza.openclinica.domain.rule.RuleSetRuleBean;
+import org.akaza.openclinica.logic.rulerunner.ExecutionMode;
+import org.akaza.openclinica.logic.rulerunner.RuleRunner.RuleRunnerMode;
+import org.akaza.openclinica.service.crfdata.DynamicsMetadataService;
+import org.akaza.openclinica.service.pmanage.RandomizationRegistrar;
+import org.akaza.openclinica.service.pmanage.SeRandomizationDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+public class RandomizeActionProcessor implements ActionProcessor {
+
+    DataSource ds;
+    DynamicsMetadataService itemMetadataService;
+    RuleActionRunLogDao ruleActionRunLogDao;
+    RuleSetBean ruleSet;
+    RuleSetRuleBean ruleSetRule;
+    StudyDAO sdao = null;
+    RandomizationRegistrar randomizationRegistrar = null;
+    protected final Logger logger = LoggerFactory.getLogger(getClass().getName());
+
+    public RandomizeActionProcessor(DataSource ds, DynamicsMetadataService itemMetadataService, RuleActionRunLogDao ruleActionRunLogDao, RuleSetBean ruleSet,
+            RuleSetRuleBean ruleSetRule) {
+        this.itemMetadataService = itemMetadataService;
+        this.ruleSet = ruleSet;
+        this.ruleSetRule = ruleSetRule;
+        this.ruleActionRunLogDao = ruleActionRunLogDao;
+        this.ds = ds;
+    }
+
+    public RuleActionBean execute(RuleRunnerMode ruleRunnerMode, ExecutionMode executionMode, RuleActionBean ruleAction, ItemDataBean itemDataBean,
+            String itemData, StudyBean currentStudy, UserAccountBean ub, Object... arguments) {
+
+        switch (executionMode) {
+        case DRY_RUN: {
+            if (ruleRunnerMode == RuleRunnerMode.DATA_ENTRY) {
+                return null;
+            } else {
+                return ruleAction;
+            }
+        }
+        case SAVE: {
+            if (ruleRunnerMode == RuleRunnerMode.IMPORT_DATA) {
+                return saveWithStatusUpdated(ruleAction, itemDataBean, itemData, currentStudy, ub);
+            } else {
+                return save(ruleAction, itemDataBean, itemData, currentStudy, ub);
+            }
+        }
+        default:
+            return ruleAction;
+        }
+    }
+
+    private RuleActionBean saveWithStatusUpdated(RuleActionBean ruleAction, ItemDataBean itemDataBean, String itemData, StudyBean currentStudy, UserAccountBean ub) {
+        itemDataBean.setStatus(Status.UNAVAILABLE);
+        try {
+            if (mayProceed(currentStudy.getOid())) {
+                getItemMetadataService().insert(itemDataBean, ((RandomizeActionBean) ruleAction).getProperties(), ub, ruleSet,
+                        ((RandomizeActionBean) ruleAction).getStratificationFactors());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return ruleAction;
+    }
+
+    private RuleActionBean save(RuleActionBean ruleAction, ItemDataBean itemDataBean, String itemData, StudyBean currentStudy, UserAccountBean ub) {
+        try {
+            if (mayProceed(currentStudy.getOid())) {
+                getItemMetadataService().insert(itemDataBean.getId(), ((RandomizeActionBean) ruleAction).getProperties(), ub, ruleSet,
+                        ((RandomizeActionBean) ruleAction).getStratificationFactors());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return ruleAction;
+    }
+
+    private DynamicsMetadataService getItemMetadataService() {
+        return itemMetadataService;
+    }
+
+    private boolean mayProceed(String studyOid) throws Exception {
+        boolean accessPermission = false;
+        StudyBean siteStudy = getStudy(studyOid);
+        StudyBean study = getParentStudy(studyOid);
+        StudyParameterValueDAO spvdao = new StudyParameterValueDAO(ds);
+        StudyParameterValueBean pStatus = spvdao.findByHandleAndStudy(study.getId(), "randomization");
+
+        randomizationRegistrar = new RandomizationRegistrar();
+        SeRandomizationDTO seRandomizationDTO = randomizationRegistrar.getCachedRandomizationDTOObject(study.getOid().toString(), false);
+        if (seRandomizationDTO == null) {
+            logger.error("Failed to retrieve randomization DTO for study: {}. Check moduleManager setting in datainfo.properties.", study.getOid());
+            return false;
+        }
+        String randomizationStatusFromOCUI = seRandomizationDTO.getStatus();
+
+        String randomizationStatusFromOC = pStatus.getValue().toString();
+        String studyStatus = study.getStatus().getName().toString();
+        String siteStatus = siteStudy.getStatus().getName().toString();
+        logger.info("randomizationStatusFromOCUI: {}  randomizationStatusFromOC: {}  studyStatus: {}  siteStatus: {}",
+                randomizationStatusFromOCUI, randomizationStatusFromOC, studyStatus, siteStatus);
+        if (randomizationStatusFromOC.equalsIgnoreCase("enabled") && studyStatus.equalsIgnoreCase("available")
+                && siteStatus.equalsIgnoreCase("available") && randomizationStatusFromOCUI.equalsIgnoreCase("ACTIVE")) {
+            accessPermission = true;
+        }
+        return accessPermission;
+    }
+
+    private StudyBean getStudy(String oid) {
+        sdao = new StudyDAO(ds);
+        StudyBean studyBean = (StudyBean) sdao.findByOid(oid);
+        return studyBean;
+    }
+
+    private StudyBean getParentStudy(String studyOid) {
+        StudyBean study = getStudy(studyOid);
+        if (study.getParentStudyId() == 0) {
+            return study;
+        } else {
+            StudyBean parentStudy = (StudyBean) sdao.findByPK(study.getParentStudyId());
+            return parentStudy;
+        }
+    }
+}

--- a/core/src/main/java/org/akaza/openclinica/service/RandomizeService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/RandomizeService.java
@@ -1,8 +1,8 @@
 /*
  * LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
- * For details see: https://www.libreclinica.org/download.html#headLicense
- *
+
+ * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
  * copyright (C) 2020 - 2026 LibreClinica
@@ -35,6 +35,7 @@ package org.akaza.openclinica.service;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 
 import javax.sql.DataSource;
 
@@ -85,11 +86,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-// Modified: SSL certificate verification skip (self-signed cert support)
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.ssl.SSLContextBuilder;
 
 public class RandomizeService extends RandomizationRegistrar {
     protected final Logger logger = LoggerFactory.getLogger(getClass().getName());
@@ -107,24 +103,9 @@ public class RandomizeService extends RandomizationRegistrar {
     private StudyEventDAO studyEventDAO;
     private EventDefinitionCRFDAO eventDefinitionCRFDAO;
     private ExpressionService expressionService;
-    // Modified: SSL verification skip for self-signed certificate environments
-    HttpComponentsClientHttpRequestFactory requestFactory = createSslSkipRequestFactory();
+    HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
     public static final int RANDOMIZATION_READ_TIMEOUT = 10000;
     StudyDAO sdao = null;
-
-    private static HttpComponentsClientHttpRequestFactory createSslSkipRequestFactory() {
-        try {
-            SSLContextBuilder builder = new SSLContextBuilder();
-            builder.loadTrustMaterial(null, (chain, authType) -> true);
-            CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(builder.build())
-                .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                .build();
-            return new HttpComponentsClientHttpRequestFactory(httpClient);
-        } catch (Exception e) {
-            return new HttpComponentsClientHttpRequestFactory();
-        }
-    }
 
     public RandomizeService(DataSource ds) {
         this.ds = ds;
@@ -162,7 +143,9 @@ public class RandomizeService extends RandomizationRegistrar {
         String randomiseUrl = randomization.getUrl();
         String username = randomization.getUsername();
         String password = randomization.getPassword();
-        String timezone = "America/New_York";
+        // Site registration requires a timezone; use the server default. The
+        // external service only stores it per site and it does not affect allocation.
+        String timezone = TimeZone.getDefault().getID();
 
         HttpHeaders headers = createHeaders(username, password);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);

--- a/core/src/main/java/org/akaza/openclinica/service/RandomizeService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/RandomizeService.java
@@ -1,0 +1,346 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+ * For details see: https://www.libreclinica.org/download.html#headLicense
+ *
+ * copyright (C) 2003 - 2011 Akaza Research
+ * copyright (C) 2003 - 2019 OpenClinica
+ * copyright (C) 2020 - 2026 LibreClinica
+ * copyright (C) 2026 UMIN (University Hospital Medical Information Network)
+ *
+ * Author:  Yoshiteru Chiba
+ * Notice:  Developed under a service-agreement contract with UMIN;
+ *          copyright in this port has been assigned to UMIN. The
+ *          author retains moral rights inalienable under Article 59
+ *          of the Japanese Copyright Act. See README for full
+ *          attribution.
+ *
+ * Modifications:
+ *   - Ported from OpenClinica v3.x; date: 2026-03-11 - 2026-03-12.
+ *   - CommonsClientHttpRequestFactory replaced with
+ *     HttpComponentsClientHttpRequestFactory
+ *     (commons-httpclient 3.x -> httpclient 4.5.7, required by Spring 5).
+ *   - org.json.JSONObject replaced with
+ *     com.fasterxml.jackson.databind.JsonNode / ObjectMapper
+ *     (spring-security-oauth2 1.x JSON removed in Spring 5 environment).
+ *
+ * License selection:
+ *   The OpenClinica original was licensed under LGPL v2.1 or later.
+ *   Per LGPL v2.1 section 13, this work selects version 3.0 of the GNU
+ *   Lesser General Public License, matching the upstream LibreClinica
+ *   distribution license.
+ */
+package org.akaza.openclinica.service;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.bean.managestudy.StudyBean;
+import org.akaza.openclinica.bean.managestudy.StudyGroupBean;
+import org.akaza.openclinica.bean.managestudy.StudySubjectBean;
+import org.akaza.openclinica.bean.submit.EventCRFBean;
+import org.akaza.openclinica.bean.submit.ItemBean;
+import org.akaza.openclinica.bean.submit.ItemDataBean;
+import org.akaza.openclinica.bean.submit.SubjectBean;
+import org.akaza.openclinica.dao.hibernate.DynamicsItemFormMetadataDao;
+import org.akaza.openclinica.dao.hibernate.DynamicsItemGroupMetadataDao;
+import org.akaza.openclinica.dao.login.UserAccountDAO;
+import org.akaza.openclinica.dao.managestudy.EventDefinitionCRFDAO;
+import org.akaza.openclinica.dao.managestudy.StudyDAO;
+import org.akaza.openclinica.dao.managestudy.StudyEventDAO;
+import org.akaza.openclinica.dao.managestudy.StudyGroupClassDAO;
+import org.akaza.openclinica.dao.managestudy.StudyGroupDAO;
+import org.akaza.openclinica.dao.managestudy.StudySubjectDAO;
+import org.akaza.openclinica.dao.submit.EventCRFDAO;
+import org.akaza.openclinica.dao.submit.ItemDAO;
+import org.akaza.openclinica.dao.submit.ItemDataDAO;
+import org.akaza.openclinica.dao.submit.ItemFormMetadataDAO;
+import org.akaza.openclinica.dao.submit.ItemGroupDAO;
+import org.akaza.openclinica.dao.submit.ItemGroupMetadataDAO;
+import org.akaza.openclinica.dao.submit.SectionDAO;
+import org.akaza.openclinica.dao.submit.SubjectDAO;
+import org.akaza.openclinica.domain.rule.RuleSetBean;
+import org.akaza.openclinica.domain.rule.action.StratificationFactorBean;
+import org.akaza.openclinica.service.pmanage.RandomizationRegistrar;
+import org.akaza.openclinica.service.pmanage.SeRandomizationDTO;
+import org.akaza.openclinica.service.rule.expression.ExpressionService;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+// Modified: use HttpComponentsClientHttpRequestFactory (Spring 5 compatible)
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+// Modified: use Jackson instead of org.json.JSONObject (not available in Spring 5 environment)
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+// Modified: SSL certificate verification skip (self-signed cert support)
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.ssl.SSLContextBuilder;
+
+public class RandomizeService extends RandomizationRegistrar {
+    protected final Logger logger = LoggerFactory.getLogger(getClass().getName());
+    private final String ESCAPED_SEPERATOR = "\\.";
+    private DynamicsItemFormMetadataDao dynamicsItemFormMetadataDao;
+    private DynamicsItemGroupMetadataDao dynamicsItemGroupMetadataDao;
+    DataSource ds;
+    private EventCRFDAO eventCRFDAO;
+    private ItemDataDAO itemDataDAO;
+    private ItemDAO itemDAO;
+    private ItemGroupDAO itemGroupDAO;
+    private SectionDAO sectionDAO;
+    private ItemFormMetadataDAO itemFormMetadataDAO;
+    private ItemGroupMetadataDAO itemGroupMetadataDAO;
+    private StudyEventDAO studyEventDAO;
+    private EventDefinitionCRFDAO eventDefinitionCRFDAO;
+    private ExpressionService expressionService;
+    // Modified: SSL verification skip for self-signed certificate environments
+    HttpComponentsClientHttpRequestFactory requestFactory = createSslSkipRequestFactory();
+    public static final int RANDOMIZATION_READ_TIMEOUT = 10000;
+    StudyDAO sdao = null;
+
+    private static HttpComponentsClientHttpRequestFactory createSslSkipRequestFactory() {
+        try {
+            SSLContextBuilder builder = new SSLContextBuilder();
+            builder.loadTrustMaterial(null, (chain, authType) -> true);
+            CloseableHttpClient httpClient = HttpClients.custom()
+                .setSSLContext(builder.build())
+                .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                .build();
+            return new HttpComponentsClientHttpRequestFactory(httpClient);
+        } catch (Exception e) {
+            return new HttpComponentsClientHttpRequestFactory();
+        }
+    }
+
+    public RandomizeService(DataSource ds) {
+        this.ds = ds;
+        this.expressionService = new ExpressionService(ds);
+    }
+
+    public String getRandomizationCode(EventCRFBean eventCrfBean, List<StratificationFactorBean> stratificationFactorBeans, RuleSetBean ruleSet) {
+        // Modified: LibreClinica DAOs are not generic (type parameters removed from LC fork)
+        StudySubjectDAO ssdao = new StudySubjectDAO(ds);
+        StudySubjectBean ssBean = (StudySubjectBean) ssdao.findByPK(eventCrfBean.getStudySubjectId());
+        String identifier = ssBean.getOid();
+        StudyDAO sdao = new StudyDAO(ds);
+        StudyBean sBean = (StudyBean) sdao.findByPK(ssBean.getStudyId());
+        String siteIdentifier = sBean.getOid();
+        String name = sBean.getName();
+        UserAccountDAO udao = new UserAccountDAO(ds);
+        int userId = 0;
+        if (eventCrfBean.getUpdaterId() == 0) {
+            userId = eventCrfBean.getOwnerId();
+        } else {
+            userId = eventCrfBean.getUpdaterId();
+        }
+        UserAccountBean uBean = (UserAccountBean) udao.findByPK(userId);
+        String user = uBean.getName();
+
+        StudyBean study = getParentStudy(sBean.getOid());
+        SeRandomizationDTO randomization = null;
+
+        try {
+            randomization = getCachedRandomizationDTOObject(study.getOid(), false);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        String randomiseUrl = randomization.getUrl();
+        String username = randomization.getUsername();
+        String password = randomization.getPassword();
+        String timezone = "America/New_York";
+
+        HttpHeaders headers = createHeaders(username, password);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        // Modified: use JsonNode instead of JSONObject
+        JsonNode jsonRandObject = retrieveARandomisation(randomiseUrl, ssBean, headers);
+        if (jsonRandObject != null) {
+            return jsonRandObject.path("code").asText();
+        } else {
+            addOrUpdateASite(randomiseUrl, sBean, headers, timezone);
+            JsonNode jsonRandomisedObject = randomiseSubject(randomiseUrl, ssBean, sBean, headers, user, stratificationFactorBeans, eventCrfBean, ruleSet);
+            if (jsonRandomisedObject != null)
+                return jsonRandomisedObject.path("code").asText();
+            else
+                return "";
+        }
+    }
+
+    private String getExpressionValue(String expr, EventCRFBean eventCrfBean, RuleSetBean ruleSet) {
+        String expression = getExpressionService().constructFullExpressionIfPartialProvided(expr, ruleSet.getTarget().getValue());
+        ItemDataBean itemData = null;
+        if (expression != null && !expression.isEmpty()) {
+            ItemBean itemBean = getExpressionService().getItemBeanFromExpression(expression);
+            String itemGroupBOrdinal = getExpressionService().getGroupOrdninalCurated(expression);
+            itemData = getItemDataDAO().findByItemIdAndEventCRFIdAndOrdinal(itemBean.getId(), eventCrfBean.getId(),
+                    itemGroupBOrdinal == "" ? 1 : Integer.valueOf(itemGroupBOrdinal));
+        }
+        return itemData.getValue();
+    }
+
+    private String getStudySubjectAttrValue(String expr, EventCRFBean eventCrfBean, RuleSetBean ruleSet) {
+        String value = "";
+        // Modified: LibreClinica DAOs are not generic
+        StudySubjectDAO ssdao = new StudySubjectDAO(ds);
+        SubjectDAO subdao = new SubjectDAO(ds);
+        StudyGroupClassDAO sgcdao = new StudyGroupClassDAO(ds);
+        StudyGroupDAO sgdao = new StudyGroupDAO(ds);
+        StudyDAO sdao = new StudyDAO(ds);
+        StudySubjectBean ssBean = (StudySubjectBean) ssdao.findByPK(eventCrfBean.getStudySubjectId());
+        SubjectBean subjectBean = (SubjectBean) subdao.findByPK(ssBean.getSubjectId());
+
+        String prefix = "STUDYGROUPCLASSLIST";
+        String param = expr.split("\\.", -1)[1].trim();
+
+        if (param.equalsIgnoreCase("BIRTHDATE")) {
+            value = subjectBean.getDateOfBirth().toString();
+        } else if (param.equalsIgnoreCase("SEX")) {
+            if (String.valueOf(subjectBean.getGender()).equals("m"))
+                value = "Male";
+            else
+                value = "Female";
+        } else if (param.startsWith(prefix)) {
+            String gcName = param.substring(21, param.indexOf("\"]"));
+            StudyGroupBean sgBean = sgdao.findSubjectStudyGroup(ssBean.getId(), gcName);
+            if (sgBean != null)
+                value = sgBean.getName();
+        }
+        return value;
+    }
+
+    // Modified: return JsonNode instead of JSONObject
+    private JsonNode retrieveARandomisation(String randomiseUrl, StudySubjectBean studySubject, HttpHeaders headers) {
+        randomiseUrl = randomiseUrl + "/api/randomisation?identifier=" + studySubject.getOid();
+        RestTemplate rest = new RestTemplate(requestFactory);
+        ResponseEntity<String> response = null;
+        String body = null;
+        JsonNode jsonNode = null;
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        try {
+            response = rest.exchange(randomiseUrl, HttpMethod.GET, request, String.class);
+            body = response.getBody();
+            // Modified: use Jackson ObjectMapper instead of new JSONObject(body)
+            jsonNode = new ObjectMapper().readTree(body);
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            logger.error(ExceptionUtils.getStackTrace(e));
+        }
+        return jsonNode;
+    }
+
+    private void addOrUpdateASite(String randomiseUrl, StudyBean studyBean, HttpHeaders headers, String timezone) {
+        randomiseUrl = randomiseUrl + "/api/sites";
+        RestTemplate rest = new RestTemplate(requestFactory);
+        ResponseEntity<String> response = null;
+        MultiValueMap<String, String> siteMap = new LinkedMultiValueMap<>();
+        siteMap.add("siteIdentifier", studyBean.getOid());
+        siteMap.add("name", studyBean.getName());
+        siteMap.add("timezone", timezone);
+        HttpEntity<MultiValueMap<String, String>> siteRequest = new HttpEntity<>(siteMap, headers);
+
+        try {
+            response = rest.exchange(randomiseUrl, HttpMethod.POST, siteRequest, String.class);
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            logger.error(ExceptionUtils.getStackTrace(e));
+        }
+    }
+
+    // Modified: return JsonNode instead of JSONObject
+    private JsonNode randomiseSubject(String randomiseUrl, StudySubjectBean studySubject, StudyBean studyBean, HttpHeaders headers, String user,
+            List<StratificationFactorBean> stratificationFactorBeans, EventCRFBean eventCrfBean, RuleSetBean ruleSet) {
+        int i = 1;
+        String exp = "";
+
+        randomiseUrl = randomiseUrl + "/api/randomise";
+        RestTemplate rest = new RestTemplate(requestFactory);
+        ResponseEntity<String> response = null;
+        MultiValueMap<String, String> subjectMap = new LinkedMultiValueMap<>();
+        subjectMap.add("identifier", String.valueOf(studySubject.getOid()));
+        subjectMap.add("siteIdentifier", studyBean.getOid());
+        subjectMap.add("user", user);
+        for (StratificationFactorBean stratificationFactorBean : stratificationFactorBeans) {
+            exp = stratificationFactorBean.getStratificationFactor().getValue();
+            if (exp.startsWith("SS.")) {
+                subjectMap.add("question" + i, getStudySubjectAttrValue(exp, eventCrfBean, ruleSet));
+            } else {
+                String output = getExpressionValue(exp, eventCrfBean, ruleSet);
+                subjectMap.add("question" + i, output);
+            }
+            i++;
+        }
+
+        String body = null;
+        JsonNode jsonNode = null;
+        HttpEntity<MultiValueMap<String, String>> subjectRequest = new HttpEntity<>(subjectMap, headers);
+
+        try {
+            response = rest.exchange(randomiseUrl, HttpMethod.POST, subjectRequest, String.class);
+            body = response.getBody();
+            // Modified: use Jackson ObjectMapper instead of new JSONObject(body)
+            jsonNode = new ObjectMapper().readTree(body);
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            logger.error(ExceptionUtils.getStackTrace(e));
+        }
+        return jsonNode;
+    }
+
+    HttpHeaders createHeaders(final String username, final String password) {
+        return new HttpHeaders() {
+            {
+                String auth = username + ":" + password;
+                byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset.forName("US-ASCII")));
+                String authHeader = "Basic " + new String(encodedAuth);
+                set("Authorization", authHeader);
+            }
+        };
+    }
+
+    public ExpressionService getExpressionService() {
+        return expressionService;
+    }
+
+    public void setExpressionService(ExpressionService expressionService) {
+        this.expressionService = expressionService;
+    }
+
+    public ItemDataDAO getItemDataDAO() {
+        return new ItemDataDAO(ds);
+    }
+
+    public void setItemDataDAO(ItemDataDAO itemDataDAO) {
+        this.itemDataDAO = itemDataDAO;
+    }
+
+    private StudyBean getStudy(String oid) {
+        sdao = new StudyDAO(ds);
+        StudyBean studyBean = (StudyBean) sdao.findByOid(oid);
+        return studyBean;
+    }
+
+    private StudyBean getParentStudy(String studyOid) {
+        StudyBean study = getStudy(studyOid);
+        if (study.getParentStudyId() == 0) {
+            return study;
+        } else {
+            StudyBean parentStudy = (StudyBean) sdao.findByPK(study.getParentStudyId());
+            return parentStudy;
+        }
+    }
+}

--- a/core/src/main/java/org/akaza/openclinica/service/crfdata/DynamicsMetadataService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/crfdata/DynamicsMetadataService.java
@@ -1,8 +1,8 @@
 /*
  * LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
- * For details see: https://www.libreclinica.org/download.html#headLicense
- *
+
+ * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
  * copyright (C) 2020 - 2026 LibreClinica

--- a/core/src/main/java/org/akaza/openclinica/service/crfdata/DynamicsMetadataService.java
+++ b/core/src/main/java/org/akaza/openclinica/service/crfdata/DynamicsMetadataService.java
@@ -1,11 +1,32 @@
 /*
  * LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
-
- * For details see: https://libreclinica.org/license
+ * For details see: https://www.libreclinica.org/download.html#headLicense
+ *
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
- * copyright (C) 2020 - 2024 LibreClinica
+ * copyright (C) 2020 - 2026 LibreClinica
+ * copyright (C) 2026 UMIN (University Hospital Medical Information Network)
+ *
+ * Author:  Yoshiteru Chiba
+ * Notice:  Developed under a service-agreement contract with UMIN;
+ *          copyright in this modification has been assigned to UMIN. The
+ *          author retains moral rights inalienable under Article 59
+ *          of the Japanese Copyright Act. See README for full
+ *          attribution.
+ *
+ * Modifications:
+ *   - Restored the external-randomization hook: getValue() now returns the
+ *     allocation code from RandomizeService when stratification factors are
+ *     present (the LibreClinica fork kept the stratificationFactorBeans seam
+ *     but removed the body). Added randomizeService field + accessors;
+ *     date: 2026-03-11 - 2026-03-12.
+ *
+ * License selection:
+ *   The OpenClinica original was licensed under LGPL v2.1 or later.
+ *   Per LGPL v2.1 section 13, this work selects version 3.0 of the GNU
+ *   Lesser General Public License, matching the upstream LibreClinica
+ *   distribution license.
  */
 package org.akaza.openclinica.service.crfdata;
 
@@ -49,6 +70,7 @@ import org.akaza.openclinica.domain.rule.RuleSetBean;
 import org.akaza.openclinica.domain.rule.action.PropertyBean;
 import org.akaza.openclinica.domain.rule.action.StratificationFactorBean;
 import org.akaza.openclinica.exception.OpenClinicaException;
+import org.akaza.openclinica.service.RandomizeService;
 import org.akaza.openclinica.service.rule.expression.ExpressionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,10 +86,21 @@ public class DynamicsMetadataService implements MetadataServiceInterface {
     private EventDefinitionCRFDAO eventDefinitionCRFDAO;
     private ExpressionService expressionService;
     private UserAccountDAO uadao;
-    
+    // External randomization service integration. Injected by name via
+    // Spring (applicationContext-core-service.xml). May be null if not wired.
+    private RandomizeService randomizeService;
+
     public DynamicsMetadataService(DataSource ds) {
         this.ds = ds;
         this.uadao = new UserAccountDAO(this.ds);
+    }
+
+    public RandomizeService getRandomizeService() {
+        return randomizeService;
+    }
+
+    public void setRandomizeService(RandomizeService randomizeService) {
+        this.randomizeService = randomizeService;
     }
 
     public boolean hide(Object metadataBean, EventCRFBean eventCrfBean) {
@@ -422,6 +455,14 @@ public class DynamicsMetadataService implements MetadataServiceInterface {
 
     private String getValue(PropertyBean property, RuleSetBean ruleSet, EventCRFBean eventCrfBean,List<StratificationFactorBean> stratificationFactorBeans) {
         String value = null;
+        // Randomization hook: when stratification factors are present the value to be
+        // written is the allocation code obtained from the external randomization
+        // service via a live HTTP call. Null-guarded so that an unwired
+        // randomizeService bean degrades gracefully instead of throwing.
+        if (stratificationFactorBeans != null && !stratificationFactorBeans.isEmpty()
+                && getRandomizeService() != null) {
+            return getRandomizeService().getRandomizationCode(eventCrfBean, stratificationFactorBeans, ruleSet);
+        }
         if (property.getValue() != null && property.getValue().length() > 0) {
             value = property.getValue();
             logger.info("Value from property value is : {}", value);

--- a/core/src/main/java/org/akaza/openclinica/service/pmanage/RandomizationRegistrar.java
+++ b/core/src/main/java/org/akaza/openclinica/service/pmanage/RandomizationRegistrar.java
@@ -1,8 +1,8 @@
 /*
  * LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
- * For details see: https://www.libreclinica.org/download.html#headLicense
- *
+
+ * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
  * copyright (C) 2020 - 2026 LibreClinica

--- a/core/src/main/java/org/akaza/openclinica/service/pmanage/RandomizationRegistrar.java
+++ b/core/src/main/java/org/akaza/openclinica/service/pmanage/RandomizationRegistrar.java
@@ -1,0 +1,190 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+ * For details see: https://www.libreclinica.org/download.html#headLicense
+ *
+ * copyright (C) 2003 - 2011 Akaza Research
+ * copyright (C) 2003 - 2019 OpenClinica
+ * copyright (C) 2020 - 2026 LibreClinica
+ * copyright (C) 2026 UMIN (University Hospital Medical Information Network)
+ *
+ * Author:  Yoshiteru Chiba
+ * Notice:  Developed under a service-agreement contract with UMIN;
+ *          copyright in this port has been assigned to UMIN. The
+ *          author retains moral rights inalienable under Article 59
+ *          of the Japanese Copyright Act. See README for full
+ *          attribution.
+ *
+ * Modifications:
+ *   - Ported from OpenClinica v3.x; date: 2026-03-11 - 2026-03-12.
+ *   - CommonsClientHttpRequestFactory replaced with
+ *     HttpComponentsClientHttpRequestFactory
+ *     (commons-httpclient 3.x -> httpclient 4.5.7, required by Spring 5).
+ *   - LibreClinica names these properties "sysURL"/"moduleManager"; added a
+ *     fallback that strips "MainMenu" from sysURL when sysURL.base is absent,
+ *     plus a null-guard for moduleManager to prevent NPE.
+ *   - getCachedRandomizationDTOObject: added null-guard for
+ *     seRandomizationDTO to prevent NPE.
+ *
+ * License selection:
+ *   The OpenClinica original was licensed under LGPL v2.1 or later.
+ *   Per LGPL v2.1 section 13, this work selects version 3.0 of the GNU
+ *   Lesser General Public License, matching the upstream LibreClinica
+ *   distribution license.
+ */
+package org.akaza.openclinica.service.pmanage;
+
+import java.util.Date;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+
+import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.core.EmailEngine;
+import org.akaza.openclinica.dao.core.CoreResources;
+import org.akaza.openclinica.exception.OpenClinicaSystemException;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+// Modified: CommonsClientHttpRequestFactory (Spring 3 / commons-httpclient 3.x) replaced with
+//           HttpComponentsClientHttpRequestFactory (Spring 5 / httpclient 4.5.7)
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.web.client.RestTemplate;
+
+public class RandomizationRegistrar {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass().getName());
+    public static final String AVAILABLE = "available";
+    public static final String UNAVAILABLE = "unavailable";
+    public static final String INVALID = "invalid";
+    public static final String UNKNOWN = "unknown";
+    public static final int RANDOMIZATION_READ_TIMEOUT = 5000;
+    private static final String CACHE_KEY = "randomizeObject";
+    private CacheManager cacheManager;
+    private net.sf.ehcache.Cache cache;
+
+    public RandomizationRegistrar() {
+        cacheManager = CacheManager.getInstance();
+        this.cache = cacheManager.getCache(CACHE_KEY);
+    }
+
+    public SeRandomizationDTO getRandomizationDTOObject(String studyOid) {
+        // LibreClinica compatibility: derive the base URL from sysURL when sysURL.base is unset.
+        String sysUrlBase = CoreResources.getField("sysURL.base");
+        if (sysUrlBase == null || sysUrlBase.trim().isEmpty()) {
+            String sysUrl = CoreResources.getField("sysURL");
+            if (sysUrl != null && !sysUrl.trim().isEmpty()) {
+                int idx = sysUrl.indexOf("MainMenu");
+                sysUrlBase = (idx > 0) ? sysUrl.substring(0, idx) : sysUrl;
+                if (!sysUrlBase.endsWith("/")) sysUrlBase += "/";
+            } else {
+                sysUrlBase = "";
+            }
+            logger.info("sysURL.base not set, derived from sysURL: {}", sysUrlBase);
+        }
+        String moduleManager = CoreResources.getField("moduleManager");
+        if (moduleManager == null || moduleManager.trim().isEmpty()) {
+            logger.error("moduleManager property is not set in datainfo.properties. Cannot retrieve randomization config.");
+            return null;
+        }
+        String ocUrl = sysUrlBase + "rest2/openrosa/" + studyOid;
+        String randomizationUrl = moduleManager + "/app/rest/oc/se_randomizations?studyoid=" + studyOid + "&instanceurl=" + ocUrl;
+        // Modified: use HttpComponentsClientHttpRequestFactory instead of CommonsClientHttpRequestFactory
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+        requestFactory.setReadTimeout(RANDOMIZATION_READ_TIMEOUT);
+        RestTemplate rest = new RestTemplate(requestFactory);
+
+        try {
+            SeRandomizationDTO response = rest.getForObject(randomizationUrl, SeRandomizationDTO.class);
+            if (response.getStudyOid() != null) {
+                return response;
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            logger.error(ExceptionUtils.getStackTrace(e));
+        }
+        return null;
+    }
+
+    public SeRandomizationDTO getCachedRandomizationDTOObject(String studyOid, Boolean resetCache) throws Exception {
+        SeRandomizationDTO seRandomizationDTO = null;
+        // LibreClinica compatibility: derive the base URL from sysURL when sysURL.base is unset.
+        String sysUrlBase = CoreResources.getField("sysURL.base");
+        if (sysUrlBase == null || sysUrlBase.trim().isEmpty()) {
+            String sysUrl = CoreResources.getField("sysURL");
+            if (sysUrl != null && !sysUrl.trim().isEmpty()) {
+                int idx = sysUrl.indexOf("MainMenu");
+                sysUrlBase = (idx > 0) ? sysUrl.substring(0, idx) : sysUrl;
+            } else {
+                sysUrlBase = "";
+            }
+        }
+        String mapKey = sysUrlBase + studyOid;
+        Element element = cache.get(mapKey);
+        if (element != null && element.getObjectValue() != null && !resetCache) {
+            seRandomizationDTO = (SeRandomizationDTO) element.getObjectValue();
+        }
+        if (seRandomizationDTO == null) {
+            seRandomizationDTO = getRandomizationDTOObject(studyOid);
+        }
+        if (seRandomizationDTO != null) {
+            cache.put(new Element(mapKey, seRandomizationDTO));
+        }
+        return seRandomizationDTO;
+    }
+
+    public void sendEmail(JavaMailSenderImpl mailSender, UserAccountBean user, String emailSubject, String message) throws OpenClinicaSystemException {
+        logger.info("Sending email...");
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
+            helper.setFrom(EmailEngine.getAdminEmail());
+            helper.setTo(user.getEmail());
+            helper.setSubject(emailSubject);
+            helper.setText(message);
+            mailSender.send(mimeMessage);
+            logger.debug("Email sent successfully on {}", new Date());
+        } catch (MailException me) {
+            logger.error("Email could not be sent");
+        } catch (MessagingException me) {
+            logger.error("Email could not be sent");
+        }
+    }
+
+    public String randomizeStudy(String studyOid, String studyName, UserAccountBean userAccount) {
+        String ocUrl = CoreResources.getField("sysURL.base") + "rest2/openrosa/" + studyOid;
+        String randomizationUrl = CoreResources.getField("moduleManager") + "/app/rest/oc/se_randomizations";
+        SeRandomizationDTO seRandomizationDTO = new SeRandomizationDTO();
+        seRandomizationDTO.setStudyOid(studyOid);
+        seRandomizationDTO.setInstanceUrl(ocUrl);
+        seRandomizationDTO.setOcUser_username(userAccount.getName());
+        seRandomizationDTO.setOcUser_name(userAccount.getFirstName());
+        seRandomizationDTO.setOcUser_lastname(userAccount.getLastName());
+        seRandomizationDTO.setOcUser_emailAddress(userAccount.getEmail());
+        seRandomizationDTO.setStudyName(studyName);
+        seRandomizationDTO.setOpenClinicaVersion(CoreResources.getField("OpenClinica.version"));
+
+        // Modified: use HttpComponentsClientHttpRequestFactory
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+        requestFactory.setReadTimeout(RANDOMIZATION_READ_TIMEOUT);
+        RestTemplate rest = new RestTemplate(requestFactory);
+
+        try {
+            SeRandomizationDTO response = rest.postForObject(randomizationUrl, seRandomizationDTO, SeRandomizationDTO.class);
+            if (response != null && response.getStatus() != null)
+                return response.getStatus();
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            logger.error(ExceptionUtils.getStackTrace(e));
+        }
+        return "";
+    }
+}

--- a/core/src/main/java/org/akaza/openclinica/service/pmanage/SeRandomizationDTO.java
+++ b/core/src/main/java/org/akaza/openclinica/service/pmanage/SeRandomizationDTO.java
@@ -1,0 +1,132 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+ * For details see: https://www.libreclinica.org/download.html#headLicense
+ *
+ * copyright (C) 2003 - 2011 Akaza Research
+ * copyright (C) 2003 - 2019 OpenClinica
+ * copyright (C) 2020 - 2026 LibreClinica
+ * copyright (C) 2026 UMIN (University Hospital Medical Information Network)
+ *
+ * Author:  Yoshiteru Chiba
+ * Notice:  Developed under a service-agreement contract with UMIN;
+ *          copyright in this port has been assigned to UMIN. The
+ *          author retains moral rights inalienable under Article 59
+ *          of the Japanese Copyright Act. See README for full
+ *          attribution.
+ *
+ * Modifications:
+ *   - Ported from OpenClinica v3.x; date: 2026-03-11 - 2026-03-12.
+ *   - Source content is identical to the OpenClinica original; only this
+ *     license/attribution header was added for the LibreClinica port.
+ *
+ * License selection:
+ *   The OpenClinica original was licensed under LGPL v2.1 or later.
+ *   Per LGPL v2.1 section 13, this work selects version 3.0 of the GNU
+ *   Lesser General Public License, matching the upstream LibreClinica
+ *   distribution license.
+ */
+package org.akaza.openclinica.service.pmanage;
+
+public class SeRandomizationDTO {
+
+    private Long id = null;
+    private String url=null;
+    private String username=null;
+    private String password=null;
+    private Long statusId;
+    private String status;
+    private String instanceUrl = null;
+    private String studyOid = null;
+    private String ocUser_username;
+    private String ocUser_name;
+    private String ocUser_lastname;
+    private String ocUser_emailAddress;
+    private String studyName;
+    private String OpenClinicaVersion;
+
+    public String getOpenClinicaVersion() {
+        return OpenClinicaVersion;
+    }
+    public void setOpenClinicaVersion(String openClinicaVersion) {
+        OpenClinicaVersion = openClinicaVersion;
+    }
+    public String getStudyName() {
+        return studyName;
+    }
+    public void setStudyName(String studyName) {
+        this.studyName = studyName;
+    }
+    public String getOcUser_emailAddress() {
+        return ocUser_emailAddress;
+    }
+    public void setOcUser_emailAddress(String ocUser_emailAddress) {
+        this.ocUser_emailAddress = ocUser_emailAddress;
+    }
+    public String getOcUser_username() {
+        return ocUser_username;
+    }
+    public void setOcUser_username(String ocUser_username) {
+        this.ocUser_username = ocUser_username;
+    }
+    public String getOcUser_name() {
+        return ocUser_name;
+    }
+    public void setOcUser_name(String ocUser_name) {
+        this.ocUser_name = ocUser_name;
+    }
+    public String getOcUser_lastname() {
+        return ocUser_lastname;
+    }
+    public void setOcUser_lastname(String ocUser_lastname) {
+        this.ocUser_lastname = ocUser_lastname;
+    }
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+    public String getUrl() {
+        return url;
+    }
+    public void setUrl(String url) {
+        this.url = url;
+    }
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    public String getPassword() {
+        return password;
+    }
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    public Long getStatusId() {
+        return statusId;
+    }
+    public void setStatusId(Long statusId) {
+        this.statusId = statusId;
+    }
+    public String getStatus() {
+        return status;
+    }
+    public void setStatus(String status) {
+        this.status = status;
+    }
+    public String getInstanceUrl() {
+        return instanceUrl;
+    }
+    public void setInstanceUrl(String instanceUrl) {
+        this.instanceUrl = instanceUrl;
+    }
+    public String getStudyOid() {
+        return studyOid;
+    }
+    public void setStudyOid(String studyOid) {
+        this.studyOid = studyOid;
+    }
+}

--- a/core/src/main/java/org/akaza/openclinica/service/pmanage/SeRandomizationDTO.java
+++ b/core/src/main/java/org/akaza/openclinica/service/pmanage/SeRandomizationDTO.java
@@ -1,8 +1,8 @@
 /*
  * LibreClinica is distributed under the
  * GNU Lesser General Public License (GNU LGPL).
- * For details see: https://www.libreclinica.org/download.html#headLicense
- *
+
+ * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
  * copyright (C) 2020 - 2026 LibreClinica

--- a/core/src/main/resources/org/akaza/openclinica/applicationContext-core-service.xml
+++ b/core/src/main/resources/org/akaza/openclinica/applicationContext-core-service.xml
@@ -24,7 +24,13 @@
     <bean id="dynamicsMetadataService" class="org.akaza.openclinica.service.crfdata.DynamicsMetadataService" autowire="byName">
         <constructor-arg ref="dataSource"/>
     </bean>
-    
+
+    <!-- External randomization service integration. Injected by name
+         into dynamicsMetadataService (autowire="byName" -> setRandomizeService). -->
+    <bean id="randomizeService" class="org.akaza.openclinica.service.RandomizeService">
+        <constructor-arg ref="dataSource"/>
+    </bean>
+
     <bean id="ruleSetService" class="org.akaza.openclinica.service.rule.RuleSetService" autowire="byName">
         <property name="dataSource" ref="dataSource"/>
         <property name="beanPropertyService" ref="beanPropertyService"/>

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -10,3 +10,4 @@ community.
 | [Set Up a Development Machine (Windows)](development/dev-machine-windows.md) | Description of steps necessary for setting up a development environment for LibreClinica on Windows. |
 | [Using Containers for Development](development/containers.md)        | Description how to use containers for development |
 | [Development Workflows](development/developer.md)                    | Information about LibreClinica development and contribution workflows |
+| [External Randomization Module API](development/randomization-module-api.md) | REST endpoints an external randomization module must implement for the opt-in randomization delegation. |

--- a/docs/development/randomization-module-api.md
+++ b/docs/development/randomization-module-api.md
@@ -1,0 +1,162 @@
+# External Randomization Module API
+
+LibreClinica can **delegate subject randomization to an external module**
+("module manager") instead of allocating subjects itself. The feature is
+**opt-in**: it is inert unless a study is configured for it and the
+`moduleManager` property is set.
+
+LibreClinica contains **no randomization logic of its own**. It collects the
+allocation factors, calls the endpoints described below, records the returned
+allocation code in the CRF, and leaves the choice of method (simple, permuted
+block, stratified, minimization, …), the blinding strategy, and the meaning of
+the returned code entirely to the module.
+
+This page is the reference for the **mandatory REST endpoints a module must
+implement** to interoperate with LibreClinica, so that integrators do not have
+to reverse-engineer them from the code.
+
+## Configuration
+
+| Property (`datainfo.properties`) | Meaning |
+|---|---|
+| `moduleManager` | Base URL of the external module. Leave empty to disable randomization; the application then makes no calls and starts normally. |
+| `sysURL` / `sysURL.base` | Used to build the OpenRosa instance URL passed to the module. When `sysURL.base` is unset it is derived from `sysURL` by stripping `MainMenu`. |
+
+## Two base URLs
+
+There are **two distinct bases** and they are not the same host in general:
+
+1. **`moduleManager`** — used for the per-study *configuration* and *study
+   registration* calls (`/app/rest/oc/se_randomizations`).
+2. **`config.url`** — the value returned in the `url` field of the
+   configuration response; used for the per-subject *randomisation* calls
+   (`/api/...`). These calls use **HTTP Basic authentication** with the
+   `username` / `password` from the configuration response.
+
+## Endpoints
+
+### 1. Get study configuration — `GET {moduleManager}/app/rest/oc/se_randomizations`
+
+Query parameters:
+
+| Param | Value |
+|---|---|
+| `studyoid` | Study OID |
+| `instanceurl` | `{sysURL.base}rest2/openrosa/{studyOid}` |
+
+Returns a `SeRandomizationDTO` (JSON). Relevant fields LibreClinica reads:
+
+| Field | Use |
+|---|---|
+| `url` | Base URL for the `/api/...` randomisation calls |
+| `username`, `password` | Basic-auth credentials for the `/api/...` calls |
+| `status` | Must be `ACTIVE` for randomisation to proceed |
+| `studyOid` | Must be non-null; a null `studyOid` is treated as "no configuration" |
+
+The configuration is cached per study.
+
+### 2. Register a study — `POST {moduleManager}/app/rest/oc/se_randomizations`
+
+Request body (`SeRandomizationDTO`, JSON): `studyOid`, `instanceUrl`,
+`ocUser_username`, `ocUser_name`, `ocUser_lastname`, `ocUser_emailAddress`,
+`studyName`, `openClinicaVersion`. Response: a `SeRandomizationDTO` whose
+`status` reports the registration result.
+
+### 3. Look up an existing allocation — `GET {config.url}/api/randomisation`
+
+Auth: Basic. Query parameter:
+
+| Param | Value |
+|---|---|
+| `identifier` | Study-subject OID |
+
+If the subject is already randomised, return a JSON object containing a
+`code` field with the allocation code. If not, return a response that is not a
+`code`-bearing JSON object (e.g. `404`); LibreClinica then proceeds to
+register the site and randomise.
+
+### 4. Register / update a site — `POST {config.url}/api/sites`
+
+Auth: Basic. Content type: `application/x-www-form-urlencoded`.
+
+| Param | Value |
+|---|---|
+| `siteIdentifier` | Study OID |
+| `name` | Study name |
+| `timezone` | Server default timezone (IANA id) |
+
+### 5. Randomise a subject — `POST {config.url}/api/randomise`
+
+Auth: Basic. Content type: `application/x-www-form-urlencoded`.
+
+| Param | Value |
+|---|---|
+| `identifier` | Study-subject OID |
+| `siteIdentifier` | Study OID |
+| `user` | Username of the operator who triggered the action |
+| `question1` … `questionN` | Allocation factors, in the order the rule defines them |
+
+Allocation factors are resolved as follows: a factor expression starting with
+`SS.` is taken from subject attributes (`SS.SEX` → `Male`/`Female`,
+`SS.BIRTHDATE`, `SS.STUDYGROUPCLASSLIST["<class>"]`); any other expression is
+resolved from the corresponding eCRF item value. The response must be a JSON
+object containing the allocation `code`, which LibreClinica writes back into
+the designated CRF item.
+
+## Activation gate
+
+A `RANDOMIZE` rule action runs the randomisation calls only when **all** of the
+following hold (see `RandomizeActionProcessor.mayProceed`):
+
+- LibreClinica study parameter `randomization` = `enabled`
+- parent study status = `available`
+- site status = `available`
+- configuration `status` (from endpoint 1) = `ACTIVE`
+
+If any condition fails, LibreClinica records nothing and makes no `/api/...`
+calls.
+
+## Idempotency and double-allocation safety
+
+LibreClinica does **not** keep a per-subject guard against re-running a
+`RANDOMIZE` action. Unlike other rule actions (INSERT, EMAIL, …) it does not use
+the `RuleActionRunLog`, so the action is re-evaluated whenever its target CRF is
+saved again — for example an administrative edit of an already-entered form, or
+a re-import of existing subject data. The activation gate above checks only
+study/site status and the configuration `status`; it does not consider whether
+the subject has already been allocated. Re-firing on the same subject is
+therefore a legitimate, expected flow.
+
+Because of this, **preventing double allocation is the module's responsibility**,
+keyed on the subject identifier (plus study). A conforming module MUST:
+
+- **`GET /api/randomisation`** — look up an existing allocation by `identifier`
+  and, if one exists, return the **same** allocation `code` (HTTP 200). If the
+  subject is not yet allocated, return a response that carries **no `code`**
+  (e.g. HTTP 404). Do **not** return `200` with an empty / `{}` body: LibreClinica
+  would otherwise write an empty code and never randomise.
+- **`POST /api/randomise`** — be **idempotent**. If the same `identifier` (within
+  the same study) is already allocated, return the existing `code` instead of
+  creating a new allocation. This covers the case where the lookup is skipped, or
+  a race occurs between the lookup and the randomise call.
+
+The allocation identity key is the **subject identifier (subject OID) + study**.
+Re-firing on the same subject then returns the same code, and LibreClinica
+records it idempotently.
+
+Note: this protects only against re-allocation of the **same** subject OID. It
+cannot protect against the **same person enrolled under a different subject
+OID** (a duplicate-enrollment data-entry error), which is outside the
+randomization layer and must be handled by subject-registration controls.
+
+## Notes
+
+- **LibreClinica does not interpret the returned `code`** (arm name, kit
+  number, or masked code). The method, the blinding, and the returned content
+  are the module's responsibility. For a blinded trial the module can return
+  only the allocation code; the CRF design (item placement, display settings,
+  role permissions) controls who can see it. Keep the module's returned content
+  and the CRF-side disclosure design consistent.
+- **Graceful degradation:** if `moduleManager` is unset, or the configuration
+  is missing or not `ACTIVE`, no calls are made and the application runs
+  normally.

--- a/docs/development/sidebar.md
+++ b/docs/development/sidebar.md
@@ -2,3 +2,4 @@
 * [Set Up a Development Machine (Windows)](development/dev-machine-windows.md "setting up a development environment on Windows")
 * [Using Containers for Development](development/containers.md "using containers for development")
 * [Development Workflows](development/developer.md "development and contribution workflows")
+* [External Randomization Module API](development/randomization-module-api.md "REST endpoints a randomization module must implement")

--- a/web/src/main/filters/datainfo.properties
+++ b/web/src/main/filters/datainfo.properties
@@ -110,19 +110,6 @@ mailErrorMsg=developers@openclinica.org
 sysURL=http://localhost:8080/${WEBAPP}/MainMenu
 
 #############################################################################
-# 8b - moduleManager
-#
-# Base URL of the external randomization module. Used by the
-# randomization feature to fetch the per-study allocation configuration
-# (/app/rest/oc/se_randomizations) and to perform allocation requests.
-# Leave empty to disable randomization requests: the feature degrades
-# gracefully and the application starts normally when this is unset.
-#
-# OPTIONAL
-#############################################################################
-moduleManager=
-
-#############################################################################
 # 9 - max_inactive_interval
 #
 # This is maximum time interval between client requests. That is,
@@ -378,3 +365,16 @@ ldap.userData.organization=company
 # and displays a "Manual Download" section within "Tasks" menu. Valid
 # values: [true|false(default)]. 
 display.manual=false
+
+#############################################################################
+# 25 - moduleManager
+#
+# Base URL of the external randomization module. Used by the
+# randomization feature to fetch the per-study allocation configuration
+# (/app/rest/oc/se_randomizations) and to perform allocation requests.
+# Leave empty to disable randomization requests: the feature degrades
+# gracefully and the application starts normally when this is unset.
+#
+# OPTIONAL
+#############################################################################
+moduleManager=

--- a/web/src/main/filters/datainfo.properties
+++ b/web/src/main/filters/datainfo.properties
@@ -110,6 +110,19 @@ mailErrorMsg=developers@openclinica.org
 sysURL=http://localhost:8080/${WEBAPP}/MainMenu
 
 #############################################################################
+# 8b - moduleManager
+#
+# Base URL of the external randomization module. Used by the
+# randomization feature to fetch the per-study allocation configuration
+# (/app/rest/oc/se_randomizations) and to perform allocation requests.
+# Leave empty to disable randomization requests: the feature degrades
+# gracefully and the application starts normally when this is unset.
+#
+# OPTIONAL
+#############################################################################
+moduleManager=
+
+#############################################################################
 # 9 - max_inactive_interval
 #
 # This is maximum time interval between client requests. That is,


### PR DESCRIPTION
## Summary

This PR re-introduces the **external randomization delegation interface** on the
`lc-randomize` feature branch, as agreed in #451. It is a **faithful port of the
original OpenClinica code** that was removed from the core in #75 — not a
rewrite. Only the delegation layer is brought back (no `ViewStudyServlet`
coupling), and the root cause of the #39 NPE is addressed so that unconfigured
installs stay inert.

The feature lets LibreClinica delegate subject allocation to an **external
randomization service** that implements the OpenClinica-style REST API
(`/app/rest/oc/se_randomizations` for the per-study config, `/api/randomise`
for allocation). The delegation target is chosen by **data/config**, not
hard-coded, so any service implementing that API can be used.

Relates to #451. Background: #75 (removal), #39 (the NPE that motivated removal).

## Scope of changes (faithful port)

The four ported classes preserve the original OpenClinica logic; the only
substantive modernizations are mechanical:
- `JSONObject` → Jackson `JsonNode`/`ObjectMapper` for response parsing;
- LibreClinica-specific glue (non-generic DAOs, `sysURL.base` derivation);
- a **null-guard** on the cached config lookup (the #39 fix, see below).

No behavioural change was made to the REST call flow itself relative to the
original OpenClinica implementation.

## What it does

- Adds a **RANDOMIZE rule action** (the `ActionType` is already present on this
  base). On a CRF item `Save`, `RandomizeActionProcessor` collects the
  configured stratification factors, calls the external service over REST, and
  writes the returned allocation code back into a CRF item.
- Target is configured by data: the global `moduleManager` URL
  (`datainfo.properties`) plus the per-study config returned by
  `se_randomizations`.

## Why it is safe — the #39 root cause

#39 was an NPE when **displaying a Study**, because the old code called the
randomization endpoint **unconditionally** and dereferenced a null cache / null
response. We traced the deeper cause: the LibreClinica Spring 3→5 / Hibernate
3→5 migration (`8c68f66e9`) swapped the ehcache `RegionFactory` for a
*named* `CacheManager`, which made the `randomizeObject` cache invisible to the
registrar's `CacheManager.getInstance()` (the anonymous singleton) →
`getCache("randomizeObject")` returned `null` → `cache.get(...)` NPE. OpenClinica
never hit this because it froze the old `RegionFactory`. The interface was then
removed in #75 to stop unconfigured installs from crashing.

This port is **opt-in and null-guarded end to end**:
- When `moduleManager` is unset, the registrar returns `null` **without any HTTP
  call**; `RandomizeActionProcessor.mayProceed()` returns `false`; the app
  starts and runs normally.
- The crashing `ViewStudyServlet` path is **not** reintroduced — activation is
  only through the opt-in RANDOMIZE rule action.

## Wiring

- `ActionProcessorFacade` dispatches `RANDOMIZE` → `RandomizeActionProcessor`.
- `DynamicsMetadataService` regains a null-guarded `randomizeService` hook
  (current `lc-develop` kept only the `stratificationFactors` seam).
- A `randomizeService` bean is added (autowired by name).
- `core/pom.xml` declares `jackson-databind` and `httpcore` explicitly (used by
  the REST client; previously only transitive).
- `datainfo.properties` gains an **OPTIONAL, empty** `moduleManager` key.

## Verification — real communication, end-to-end (not a mock)

Built with `mvn -B -DskipTests clean -pl web -am package` → **BUILD SUCCESS**;
the four ported classes are present in the produced WAR.

End-to-end allocation was verified against a **real, running external
randomization service** (not a stub/mock), through the production browser flow,
on an isolated instance kept fully separate from production (separate port,
separate DB):

- **One subject at a time (sequential, no batch).** Six subjects were enrolled
  and randomized **individually** through the UI (enroll → schedule event →
  enter stratification factors → set the execute flag → Save fires the rule).
- **Every allocation went over the wire.** Each subject produced an independent
  `POST /api/randomise` (preceded by the config `GET` and a `POST /api/sites`),
  all returning HTTP 200 from the external service. The service's access log,
  its operation-log rows, and the LibreClinica send log line up **1:1 by
  timestamp** per subject.
- **No DB injection of allocations.** The allocation code stored in
  LibreClinica `item_data` matches the code returned by the external service for
  all six subjects; allocations were written by the rule engine from the HTTP
  response only — no allocation values were inserted by direct SQL.
- **Write-back integrity:** allocation codes are non-empty, unique, and the
  subject count equals the allocation-record count (6 = 6).
- **Stratified/permuted-block behaviour observed:** two strata consumed two
  independent permuted blocks; all groups appeared across the cohort — i.e. the
  external method behaved as expected through the live interface.

## A small improvement we'd like to propose for later

The pre-allocation lookup `GET /api/randomisation?identifier=<subjectOID>` is a
defensive idempotency check (return the existing code if the subject is already
randomized, otherwise allocate). In the original OpenClinica code this GET sends
only `identifier`, whereas the `POST /api/randomise` / `POST /api/sites` calls
also send `siteIdentifier`. Depending on how the external service authenticates
the lookup, that asymmetry can make the GET fail and fall through to the POST
path — allocation still succeeds correctly (the POST is idempotent server-side),
so there is no functional impact, but the local idempotency short-circuit does
not engage.

We've **left this exactly as in the original OpenClinica port** for this PR.
Adding `&siteIdentifier=<studyOID>` to the lookup URL would let the idempotency
short-circuit work as intended. We're happy to implement that follow-up on our
side if you'd like it — just let us know and we'll raise it separately.

## Licensing

The four ported classes and the two modified files carry the **four-party**
header — Akaza / OpenClinica / **LibreClinica 2020 - 2026** / **UMIN 2026** —
with **LGPL v3** selected under the original "v2.1 or later", port author
**Yoshiteru Chiba**, copyright assigned to UMIN.

> Open question for the maintainer: since these classes were removed in #75 and
> are ported back from the OpenClinica lineage, please advise if you'd prefer a
> different attribution for the LibreClinica copyright year on the re-introduced
> files (the modified `ActionProcessorFacade` / `DynamicsMetadataService` are
> existing LibreClinica files, so the LibreClinica copyright there is in order).
