### PR TITLE
Solves https://github.com/reliatec-gmbh/LibreClinica/issues/457

### DIFF
--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy1.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy1.jsp
@@ -150,9 +150,7 @@
   </div></div></div></div></div></div></div></div>
    </div>
   <script type="text/javascript">
-		window.body.onload = new function() {
-			onMailNotificationClick();
-		}
+    window.addEventListener('load', onMailNotificationClick);
   </script>
 
   <div style="width: 600px">

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyNew.jsp
@@ -318,9 +318,7 @@
 	</tr>
 	
 	<script type="text/javascript">
-		window.body.onload = new function() {
-			onMailNotificationClick();
-		}
+		window.addEventListener('load', onMailNotificationClick);
 	</script>
 
            <tr valign="top"><td class="formlabel"><a href="http://prsinfo.clinicaltrials.gov/definitions.html#VerificationDate" target="def_win" onClick="openDefWindow('http://prsinfo.clinicaltrials.gov/definitions.html#VerificationDate'); return false;"><fmt:message key="protocol_verification" bundle="${resword}"/>:</a></td><td>


### PR DESCRIPTION
Replacing a (java-)script throwing an exception with one that doesn't in the two JSP templates for "create new study" and "update study details" (for details, see comment in https://github.com/reliatec-gmbh/LibreClinica/issues/457).
