### PR TITLE
Further bugfixes and improvements in LCTable library and AuditUserActivity page.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,9 @@ services:
     environment:
       # Set to "jmesa" to force the legacy JMesa rendering path for any table
       # that has been migrated to HtmlFlow. Unset (or any other value) uses HtmlFlow.
+      TZ: ${TZ:-UTC}
       LC_TABLE_RENDERING: ${LC_TABLE_RENDERING:-htmlflow}
+
     develop:
       watch:
         # restart on config file changes
@@ -32,11 +34,14 @@ services:
   db:
     image: docker.io/library/postgres:16-alpine
     environment:
+      TZ: ${TZ:-UTC}
       POSTGRES_PASSWORD: clinica
       POSTGRES_USER: clinica
       POSTGRES_DB: libreclinica
 
   smtp:
     image: docker.io/marlonb/mailcrab:v1.1.0
+    environment:
+      TZ: ${TZ:-UTC}
     ports:
       - "127.0.0.1:1080:1080"

--- a/web/src/main/java/org/akaza/openclinica/control/admin/AuditUserLoginTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/admin/AuditUserLoginTable.java
@@ -43,7 +43,7 @@ public class AuditUserLoginTable {
         textCol("userName", "User Name", 5, AuditUserLoginBean::getUserName),
         textCol("loginAttemptDate", "Attempt Date", 7,
             textFilter(TIMESTAMP_FILTER_FOR_HTML_VALIDATION, TIMESTAMP_FILTER_MESSAGE),
-            AuditUserLoginBean::getLoginAttemptDate, LCTableUtil::utcTimestampToString
+            AuditUserLoginBean::getLoginAttemptDate, LCTableUtil::timestampToString
         ),
         enumCol("loginStatus", "Status", 7,
             AuditUserLoginBean::getLoginStatus, Arrays.asList(LoginStatus.values()), LoginStatus::toString, LoginStatus::name

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
@@ -111,7 +111,7 @@ public class LCTable<T>  {
     private void renderFilters(Tr<?> tr, LCTableContext<T> ctx) {
         // Render a filter input for each column
         columns.forEach(col -> {
-            if (col.filterDef != null) {
+            if (col.isFilterable()) {
                 col.filterDef.renderFilter(tr, ctx, col, this);
             } else {
                 tr.td().__();   // insert empty <td> to fill column cell when there is no filter

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
@@ -74,7 +74,7 @@ public class LCTable<T>  {
      */
     private void renderColumnName(Tr<?> tr, LCTableColumnDef<T> col, LCTableContext<T> ctx) {
         final String widthStyle = "width: " + col.columnWidth + "rem";
-        if (!col.isSortable) {
+        if (!col.isSortable()) {
             // Non-sortable column: just render the header text without a link
             tr.th().attrStyle(widthStyle).text(col.columnDisplayName).__();
         } else {

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
@@ -28,10 +28,14 @@ import java.util.function.Function;
  */
 public class LCTableColumnDef<T> {
 
-    // synonyms of true, false and null for better readability in column definitions
-    // for use in 'sortable' field of column definitions
-    public static final boolean SORTABLE = true;
-    public static final boolean NOT_SORTABLE = false;
+    public enum Sortability {
+        SORTABLE,
+        NOT_SORTABLE;
+        public boolean isSortable() { return this == SORTABLE; }
+    }
+    public static final Sortability SORTABLE = Sortability.SORTABLE;
+    public static final Sortability NOT_SORTABLE = Sortability.NOT_SORTABLE;
+
     // for use in 'filterDef' field of column definitions
     public static final LCTableFilterDef NO_FILTER = null;
 
@@ -45,7 +49,7 @@ public class LCTableColumnDef<T> {
     public final double columnWidth;
 
     /** Flag to indicate whether column data is sortable or not */
-    public final boolean isSortable;
+    public final Sortability sortability;
 
     /** Optional filter definition for this column. */
     public final LCTableFilterDef filterDef;                // null if no filter is foreseen for this column
@@ -54,18 +58,23 @@ public class LCTableColumnDef<T> {
     public final BiConsumer<Tr<?>, T> cellRenderer;
 
     // General constructor
-    public LCTableColumnDef(String columnName, String columnDisplayName, double columnWidth, boolean isSortable, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
+    public LCTableColumnDef(String columnName, String columnDisplayName, double columnWidth, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
         this.columnName = columnName;
         this.columnDisplayName = columnDisplayName;
         this.columnWidth = columnWidth;
-        this.isSortable = isSortable;
+        this.sortability = sortability;
         this.filterDef = filterDef;
         this.cellRenderer = cellRenderer;
     }
 
+
+    public boolean isSortable() {
+        return this.sortability.isSortable();
+    }
+
     // Basic factory method
-    public static <T> LCTableColumnDef<T> columnDef(String columnName, String displayName, double columnWidth, boolean sortable, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, columnWidth, sortable, filterDef, cellRenderer);
+    public static <T> LCTableColumnDef<T> columnDef(String columnName, String displayName, double columnWidth, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
+        return new LCTableColumnDef<>(columnName, displayName, columnWidth, sortability, filterDef, cellRenderer);
     }
 
     // --- 1. Null-safe cell generator ('Optional'-based) ---
@@ -100,47 +109,47 @@ public class LCTableColumnDef<T> {
     // --- 3. Column factory methods for text columns ---
 
     public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Function<T, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, true, new LCTableFilterDef.Text(), nullSafeColText(renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(renderer));
     }
 
     public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, true, filterDef, nullSafeColText(renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, filterDef, nullSafeColText(renderer));
     }
 
     public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Function<T, F> extractor, Function<F, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, true, new LCTableFilterDef.Text(), nullSafeColText(extractor, renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(extractor, renderer));
     }
 
     public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, true, filterDef, nullSafeColText(extractor, renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, filterDef, nullSafeColText(extractor, renderer));
     }
 
     // --- 4. Column factory methods for enum-like types (similar to textCol, but with list of allowed value and 'select' filter ---
 
     public static <T, V> LCTableColumnDef<T> enumCol(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, true, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
     }
 
     public static <T, V> LCTableColumnDef<T> enumColNotSortable(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, false, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
     }
 
     public static <T, V> LCTableColumnDef<T> enumCol(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return new LCTableColumnDef<>(columnName, displayName, width, true, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
     }
 
     public static <T, V> LCTableColumnDef<T> enumColNotSortable(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return new LCTableColumnDef<>(columnName, displayName, width, false, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, NOT_SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
     }
 
     // --- 5. Column factory methods for custom 'td' rendering ---
 
-    public static <T> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, boolean sortable, LCTableFilterDef filterDef, BiConsumer<Td<?>, T> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, sortable, filterDef, nullSafeCell(Function.identity(), renderer));
+    public static <T> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Td<?>, T> renderer) {
+        return new LCTableColumnDef<>(columnName, displayName, width, sortability, filterDef, nullSafeCell(Function.identity(), renderer));
     }
 
-    public static <T, F> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, boolean sortable, LCTableFilterDef filterDef, Function<T, F> extractor, BiConsumer<Td<?>, F> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, sortable, filterDef, nullSafeCell(row -> row.map(extractor), renderer));
+    public static <T, F> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> extractor, BiConsumer<Td<?>, F> renderer) {
+        return new LCTableColumnDef<>(columnName, displayName, width, sortability, filterDef, nullSafeCell(row -> row.map(extractor), renderer));
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
@@ -68,9 +68,8 @@ public class LCTableColumnDef<T> {
     }
 
 
-    public boolean isSortable() {
-        return this.sortability.isSortable();
-    }
+    public boolean isSortable() { return this.sortability.isSortable();  }
+    public boolean isFilterable() { return this.filterDef != null; }
 
     // Basic factory method
     public static <T> LCTableColumnDef<T> columnDef(String columnName, String displayName, double columnWidth, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableFilterDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableFilterDef.java
@@ -87,7 +87,8 @@ public abstract class LCTableFilterDef {
                     input.addAttr("hx-on:htmx:before-request", "if(!this.validity.valid){event.preventDefault();}");
                 }
 
-                input.of(hxGetAttrs(ctx.entityPath, "closest form", "#" + table.panelId, trigger))
+                // use hxGetAttrsIgnoreActiveValue to avoid replacing the input value with the value from the response while the user is typing
+                input.of(hxGetAttrsIgnoreActiveValue(ctx.entityPath, "closest form", "#" + table.panelId, trigger))
                     .__().__();
             }).__();
         }
@@ -187,9 +188,9 @@ public abstract class LCTableFilterDef {
         // CSS selector that picks up only the pagination/sort form fields, excluding all filter inputs.
         private static final String NON_FILTER_PARAMS_SELECTOR =
             "[name=" + LCTableParams.PARAM_PAGE + "]" +
-            ",[name=" + LCTableParams.PARAM_MAX_ROWS + "]" +
-            ",[name=" + LCTableParams.PARAM_SORT_PROP + "]" +
-            ",[name=" + LCTableParams.PARAM_SORT_DIR + "]";
+                ",[name=" + LCTableParams.PARAM_MAX_ROWS + "]" +
+                ",[name=" + LCTableParams.PARAM_SORT_PROP + "]" +
+                ",[name=" + LCTableParams.PARAM_SORT_DIR + "]";
 
         @Override
         public <T, E extends Element<?, ?>> void renderFilter(Tr<E> tr, LCTableContext<T> ctx, LCTableColumnDef<T> col, LCTable<T> table) {

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
@@ -40,17 +40,36 @@ public class LCTableUtil {
     public static final String NO_HX_TRIGGER = null;          // just for better readability in method calls
 
     public static <T extends CustomAttributeGroup<T, ?>> Consumer<T> hxGetAttrs(
-        String hxGet, String hxInclude, String hxTarget, String hxTrigger
+        String hxGet, String hxInclude, String hxTarget, String hxTrigger, boolean ignoreActiveValue
     ) {
         return el -> {
             el.addAttr(HX_GET, hxGet);
             if (hxInclude != null) el.addAttr(HX_INCLUDE, hxInclude);
             el.addAttr(HX_TARGET, hxTarget);
             el.addAttr("hx-select", hxTarget);
-            el.addAttr(HX_SWAP, "morph:{morphStyle:'outerHTML',ignoreActiveValue:true}");
+            if (ignoreActiveValue) {
+                // for incremental input filters and the like, where the user may continue typing
+                // while the request is in flight: do not replace value with the value from the response
+                el.addAttr(HX_SWAP, "morph:{morphStyle:'outerHTML',ignoreActiveValue:true}");
+            } else {
+                // other cases: replace the entire target element with the response (outerHTML)
+                el.addAttr(HX_SWAP, "outerHTML");
+            }
             if (hxTrigger != null) el.addAttr(HX_TRIGGER, hxTrigger);
             el.addAttr(HX_PUSH_URL, "true");
         };
+    }
+
+    public static <T extends CustomAttributeGroup<T, ?>> Consumer<T> hxGetAttrs(
+        String hxGet, String hxInclude, String hxTarget, String hxTrigger
+    ) {
+        return hxGetAttrs(hxGet, hxInclude, hxTarget, hxTrigger, false);
+    }
+
+    public static <T extends CustomAttributeGroup<T, ?>> Consumer<T> hxGetAttrsIgnoreActiveValue(
+        String hxGet, String hxInclude, String hxTarget, String hxTrigger
+    ) {
+        return hxGetAttrs(hxGet, hxInclude, hxTarget, hxTrigger, true);
     }
 
     /**
@@ -79,7 +98,7 @@ public class LCTableUtil {
     public static <T extends Element<?, ?>> Consumer<Td<T>> linkIcon(String altTitle, String href, String imgSrc, String imgAlt) {
         return td -> td
             .a().attrHref(href).attrTitle(altTitle)
-                .img().attrSrc(imgSrc).attrAlt(imgAlt).__()
+            .img().attrSrc(imgSrc).attrAlt(imgAlt).__()
             .__();  // close a()
     }
 

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
@@ -16,7 +16,7 @@ import org.xmlet.htmlapifaster.CustomAttributeGroup;
 import org.xmlet.htmlapifaster.Element;
 import org.xmlet.htmlapifaster.Td;
 
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.function.Consumer;
 
@@ -30,9 +30,8 @@ public class LCTableUtil {
     public static final String TIMESTAMP_FILTER_MESSAGE =
         "Please enter a valid format: yyyy, yyyy-MM, yyyy-MM-dd, yyyy-MM-dd hh, or yyyy-MM-dd hh:mm (years up to 2099)";
 
-    public static String utcTimestampToString(java.util.Date date) {
-        // return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(date);     // legacy way: create a new SimpleDateFormat for each call to ensure thread safety
-        return date.toInstant().atZone(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));  // use UTC for server logs, not local timezone
+    public static String timestampToString(java.util.Date date) {
+        return date.toInstant().atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
 
     // --- HTMX helpers ---

--- a/web/src/main/webapp/WEB-INF/jsp/admin/auditUserActivity.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/auditUserActivity.jsp
@@ -91,18 +91,7 @@
 <br>
 <input type="button" onclick="confirmExit('ListUserAccounts');"  name="exit" value="<fmt:message key="exit" bundle="${resword}"/>   " class="button_medium"/>
 
-<!-- Load HTMX only on this page (user preference). HTMX is provided by the webjar
-     declared in web/pom.xml. This ensures HTMX is available for the LCTable
-     pagination links on Audit User Activity without adding the script globally. -->
-<script src="${pageContext.request.contextPath}/webjars/htmx.org/2.0.9/dist/htmx.min.js"></script>
-<script src="${pageContext.request.contextPath}/webjars/idiomorph/0.7.4/dist/idiomorph-ext.js"></script>
-<!-- The following is needed to avoid problems with browser back/forward navigation buttons. See https://htmx.org/docs/#history -->
-<script>
-if (!document.querySelector('meta[name="htmx-config"]'))
-    document.head.insertAdjacentHTML('beforeend', '<meta name="htmx-config" content=\'{"historyRestoreAsHxRequest": false}\'>');
-</script>
-
-<!-- Session-expiry redirect guard for HTMX-based LCTable requests. -->
-<script src="${pageContext.request.contextPath}/js/htmx-session-expiry-guard.js"></script>
+<!-- Include everything that is needed for proper use of HTMX with LCTable -->
+<jsp:include page="../include/useHtmx.jsp"/>
 
 <jsp:include page="../include/footer.jsp"/>

--- a/web/src/main/webapp/WEB-INF/jsp/admin/auditUserActivity.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/auditUserActivity.jsp
@@ -78,7 +78,7 @@
 <h1><span class="title_Manage"><fmt:message key="audit_user_activity" bundle="${resword}"/></span></h1>
 
 <jsp:useBean id="now" class="java.util.Date" />
-<P><I><fmt:message key="server_time_info" bundle="${resword}"/> <fmt:formatDate value="${now}" pattern="yyyy-MM-dd hh:mm"/>.</I></P>
+<P><I><fmt:message key="server_time_info" bundle="${resword}"/> <fmt:formatDate value="${now}" pattern="yyyy-MM-dd HH:mm"/>.</I></P>
 <div id="auditUserLoginDiv">
     <form  action="${pageContext.request.contextPath}/AuditUserActivity">
         <input type="hidden" name="module" value="admin">

--- a/web/src/main/webapp/WEB-INF/jsp/include/useHtmx.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/useHtmx.jsp
@@ -1,0 +1,20 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+
+<!-- This JSP fragment is used to include in a JSP page everything that is needed for HTMX to work properly
+      (especially for the implementation of / in connection with the LCTable library)
+-->
+
+<!-- Load HTMX, which is provided by the webjar declared in web/pom.xml -->
+<script src="${pageContext.request.contextPath}/webjars/htmx.org/2.0.9/dist/htmx.min.js"></script>
+
+<!-- Load the 'idiomorph' HTMX extension, which is provided by the webjar declared in web/pom.xml -->
+<script src="${pageContext.request.contextPath}/webjars/idiomorph/0.7.4/dist/idiomorph-ext.js"></script>
+
+<!-- The following is needed to avoid problems with browser back/forward navigation buttons. See https://htmx.org/docs/#history -->
+<script>
+if (!document.querySelector('meta[name="htmx-config"]'))
+    document.head.insertAdjacentHTML('beforeend', '<meta name="htmx-config" content=\'{"historyRestoreAsHxRequest": false}\'>');
+</script>
+
+<!-- Session-expiry redirect guard for HTMX-based LCTable requests -->
+<script src="${pageContext.request.contextPath}/js/htmx-session-expiry-guard.js"></script>

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy1.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/createStudy1.jsp
@@ -150,9 +150,7 @@
   </div></div></div></div></div></div></div></div>
    </div>
   <script type="text/javascript">
-		window.body.onload = new function() {
-			onMailNotificationClick();
-		}
+    window.addEventListener('load', onMailNotificationClick);
   </script>
 
   <div style="width: 600px">

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyNew.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/updateStudyNew.jsp
@@ -318,9 +318,7 @@
 	</tr>
 	
 	<script type="text/javascript">
-		window.body.onload = new function() {
-			onMailNotificationClick();
-		}
+		window.addEventListener('load', onMailNotificationClick);
 	</script>
 
            <tr valign="top"><td class="formlabel"><a href="http://prsinfo.clinicaltrials.gov/definitions.html#VerificationDate" target="def_win" onClick="openDefWindow('http://prsinfo.clinicaltrials.gov/definitions.html#VerificationDate'); return false;"><fmt:message key="protocol_verification" bundle="${resword}"/>:</a></td><td>


### PR DESCRIPTION
1. LCTableColumnDef: replaced Boolean 'isSortable' attribute with a 'sortability' attribute of enum type 'Sortability' (with two values 'SORTABLE' and 'NOT_SORTABLE') for improved type-safety.

2. LCTable: fixed bug that prevented the display of the sort order UI indicators on column headers (see the actual commit for details).

3. LCTable library: added 'isFilterable()' method to LCTableColumnDef class (as synonym for 'this.filterDef != null').

4. LCTable library: fixed the timezone issue (now using local time zone, not UTC). Furthermore, in "auditUserActivity.jsp": changed the message "Note that the 'Login Attempt Date field' is based on server time. The current server time is ..."
to use 24h time format.

Items 2-4 above address remarks in https://github.com/reliatec-gmbh/LibreClinica/issues/74#issuecomment-4994719124.