### PR TITLE
Fix `image_dir` in the Japanese locale (missing `images/ja` causes a 404)

### DIFF
--- a/core/src/main/resources/org/akaza/openclinica/i18n/format_ja.properties
+++ b/core/src/main/resources/org/akaza/openclinica/i18n/format_ja.properties
@@ -117,7 +117,7 @@ date_time_regexp=[0-9]{1,2}/[a-zA-Z]{3}/[0-9]{4} [0-9]{1,2}:[0-9]{1,2}
 # the web server, and should not be changed, unless you have created
 # a new directory with all the language-specific files inside.
 ########################################
-image_dir=ja
+image_dir=en
 
 jscalendar_language_file=calendar-ja.js
 


### PR DESCRIPTION
## Summary

PR #448 set `image_dir=ja` in `format_ja.properties`, but no corresponding
`web/src/main/webapp/images/ja/` directory was added. As a result the referenced image
returns 404 in the Japanese UI. This changes the value back to `en`.

## Details

`image_dir` is used in JSPs to build an image path:

```jsp
<img src="images/<fmt:message key="image_dir" bundle="${resformat}"/>/tab_Workflow_closed.gif" ...>
```

- It is referenced from **49 JSPs** (`include/workflow.jsp` and the study-build pages such as
  `createStudy2-8`, `defineStudyEvent1-4`, `createSubStudy`), and in all of them for the
  **same single image**, `tab_Workflow_closed.gif`.
- `web/src/main/webapp/images/en/` exists; `images/ja/` does not, and was not part of #448.

Verified against a deployed instance:

```
GET /libreclinica/images/en/tab_Workflow_closed.gif  ->  200
GET /libreclinica/images/ja/tab_Workflow_closed.gif  ->  404
```

and in the browser, the `DefineStudyEvent` page reports 1 broken image under a Japanese
locale and 0 under an English locale.

The effect is limited to that decorative tab image not being displayed; there is no layout
breakage and no functional impact. Still, it is a regression introduced by #448 and should
be corrected.

For the record, the file itself already warned about this. The comment block just above
`image_dir` in `format.properties` reads:

> The 'image_dir' points to the location of all the images in the local
> language of the site.  Note that this is a physical location within
> the web server, and should not be changed, unless you have created
> a new directory with all the language-specific files inside.

That was missed when #448 was prepared.

## Change

One line in `core/src/main/resources/org/akaza/openclinica/i18n/format_ja.properties`:

```diff
-image_dir=ja
+image_dir=en
```

## Why not add a Japanese image instead

`tab_Workflow_closed.gif` is a 26x121 image with the word "Workflow" drawn into it, so a
Japanese variant would have to be created rather than copied. That did not seem to be the
right direction:

- the Frontend page in the wiki lists images that have text on them as candidates for
  removal ("All of the images which have text on them can be removed from the
  `web\src\main\webapp\images` folder"), so a new text-bearing image would go against that;
- of the 120 files in `images/en/`, only this one is actually referenced through `image_dir`
  (there are no hard-coded `images/en/` references anywhere), so the mechanism is effectively
  vestigial;
- the new LCTable code likewise uses language-independent paths such as `images/bt_View.gif`.

Pointing `image_dir` back at `en` restores the image with the smallest possible change and
leaves the door open for removing the mechanism altogether later.

## Testing

- Rebuilt and deployed; confirmed that `images/en/tab_Workflow_closed.gif` is requested (200)
  under a Japanese locale and that no broken image remains on the affected pages.
- The rest of the Japanese UI is unaffected: `image_dir` is the only property changed, and
  `isQualifiedLocale()` still resolves `ja` for all nine bundles.
