### PR TITLE
First working implementation of LCTable-based `findSubjects` table.

### DIFF
--- a/core/src/main/resources/org/akaza/openclinica/i18n/format_ja.properties
+++ b/core/src/main/resources/org/akaza/openclinica/i18n/format_ja.properties
@@ -117,7 +117,7 @@ date_time_regexp=[0-9]{1,2}/[a-zA-Z]{3}/[0-9]{4} [0-9]{1,2}:[0-9]{1,2}
 # the web server, and should not be changed, unless you have created
 # a new directory with all the language-specific files inside.
 ########################################
-image_dir=ja
+image_dir=en
 
 jscalendar_language_file=calendar-ja.js
 

--- a/web/src/main/java/org/akaza/openclinica/control/MainMenuServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/MainMenuServlet.java
@@ -23,6 +23,7 @@ import org.akaza.openclinica.control.admin.StudyStatisticsTableFactory;
 import org.akaza.openclinica.control.admin.StudySubjectStatusStatisticsTableFactory;
 import org.akaza.openclinica.control.core.SecureController;
 import org.akaza.openclinica.control.form.FormProcessor;
+import org.akaza.openclinica.control.submit.ListStudySubjectTable;
 import org.akaza.openclinica.control.submit.ListStudySubjectTableFactory;
 import org.akaza.openclinica.dao.login.UserAccountDAO;
 import org.akaza.openclinica.dao.managestudy.DiscrepancyNoteDAO;
@@ -290,23 +291,37 @@ public class MainMenuServlet extends SecureController {
 
     private void setupListStudySubjectTable() {
 
-        ListStudySubjectTableFactory factory = new ListStudySubjectTableFactory(true);
-        factory.setStudyEventDefinitionDao(getStudyEventDefinitionDao());
-        factory.setSubjectDAO(getSubjectDAO());
-        factory.setStudySubjectDAO(getStudySubjectDAO());
-        factory.setStudyEventDAO(getStudyEventDAO());
-        factory.setStudyBean(currentStudy);
-        factory.setStudyGroupClassDAO(getStudyGroupClassDAO());
-        factory.setSubjectGroupMapDAO(getSubjectGroupMapDAO());
-        factory.setStudyDAO(getStudyDAO());
-        factory.setCurrentRole(currentRole);
-        factory.setCurrentUser(ub);
-        factory.setEventCRFDAO(getEventCRFDAO());
-        factory.setEventDefintionCRFDAO(getEventDefinitionCRFDAO());
-        factory.setStudyGroupDAO(getStudyGroupDAO());
-        factory.setStudyParameterValueDAO(getStudyParameterValueDAO());
-        String findSubjectsHtml = factory.createTable(request, response).render();
-        request.setAttribute("findSubjectsHtml", findSubjectsHtml);
+        String lcTableRendering = System.getenv("LC_TABLE_RENDERING");
+        // Use JMesa rendering only when LC_TABLE_RENDERING is explicitly set to "jmesa"
+        if (lcTableRendering != null && lcTableRendering.equalsIgnoreCase("jmesa")) {
+            // Legacy JMesa rendering path: unchanged behaviour
+            request.setAttribute("tableRenderingMode", "jmesa");
+            ListStudySubjectTableFactory factory = new ListStudySubjectTableFactory(true);
+            factory.setStudyEventDefinitionDao(getStudyEventDefinitionDao());
+            factory.setSubjectDAO(getSubjectDAO());
+            factory.setStudySubjectDAO(getStudySubjectDAO());
+            factory.setStudyEventDAO(getStudyEventDAO());
+            factory.setStudyBean(currentStudy);
+            factory.setStudyGroupClassDAO(getStudyGroupClassDAO());
+            factory.setSubjectGroupMapDAO(getSubjectGroupMapDAO());
+            factory.setStudyDAO(getStudyDAO());
+            factory.setCurrentRole(currentRole);
+            factory.setCurrentUser(ub);
+            factory.setEventCRFDAO(getEventCRFDAO());
+            factory.setEventDefintionCRFDAO(getEventDefinitionCRFDAO());
+            factory.setStudyGroupDAO(getStudyGroupDAO());
+            factory.setStudyParameterValueDAO(getStudyParameterValueDAO());
+            String findSubjectsHtml = factory.createTable(request, response).render();
+            request.setAttribute("findSubjectsHtml", findSubjectsHtml);
+        } else {
+            // HtmlFlow rendering path
+            request.setAttribute("tableRenderingMode", "htmlflow");
+            ListStudySubjectTable table = new ListStudySubjectTable(getStudySubjectDAO(), getSubjectDAO(), getStudyEventDAO(), getStudyEventDefinitionDao(),
+                getStudyGroupClassDAO(), getSubjectGroupMapDAO(), getStudyGroupDAO(), getStudyDAO(), getEventCRFDAO(), getEventDefinitionCRFDAO(),
+                getStudyParameterValueDAO(), currentStudy, currentRole, ub, locale, session);
+            String findSubjectsHtml = table.render(request);
+            request.setAttribute("findSubjectsHtml", findSubjectsHtml);
+        }
     }
 
     

--- a/web/src/main/java/org/akaza/openclinica/control/admin/AuditUserLoginTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/admin/AuditUserLoginTable.java
@@ -20,6 +20,7 @@ import org.akaza.openclinica.lctable.*;
 import static org.akaza.openclinica.lctable.LCTableColumnDef.*;
 import static org.akaza.openclinica.lctable.LCTableFilterDef.*;
 import static org.akaza.openclinica.lctable.LCTableUtil.*;
+import static org.akaza.openclinica.lctable.SafeUrl.url;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
@@ -38,6 +39,18 @@ public class AuditUserLoginTable {
         this.table = new LCTable<>("userLogins", COLUMNS, this::fetchData);
     }
 
+    /**
+     * Builds the id of an action link for a given row of this table.
+     * {@link AuditUserLoginBean#getId()} (inherited from {@code AbstractMutableDomainObject}) is the audit-log
+     * entry's own database-generated primary key -- distinct from {@link AuditUserLoginBean#getUserAccountId()},
+     * which is a foreign key to the *viewed* user account. It is a stable, unique-per-row identifier, and thus a
+     * much better fit for element ids than a row-number/index (as the legacy JSP-based table used), which shifts
+     * whenever the table is paginated/sorted/filtered.
+     */
+    private static String actionId(String action, AuditUserLoginBean row) {
+        return "userLogins-" + action + "-" + row.getId();
+    }
+
     // defines the configuration of columns for the AuditUserLogin table
     private static final List<LCTableColumnDef<AuditUserLoginBean>> COLUMNS = Arrays.asList(
         textCol("userName", "User Name", 5, AuditUserLoginBean::getUserName),
@@ -50,9 +63,9 @@ public class AuditUserLoginTable {
         ),
         textCol("details", "Details", 3, AuditUserLoginBean::getDetails),
         customTdCol("actions", "Actions", 4, NOT_SORTABLE, clearFilter(),
-            AuditUserLoginBean::getUserAccountId,
-            (td, userAccountId) ->
-                td.of(linkIcon("View", "ViewUserAccount?userId=" + userAccountId + "&viewFull=yes", "images/bt_View.gif", "View"))
+            (td, row) ->
+                td.of(actionLink(actionId("view", row), "View",
+                    url("ViewUserAccount").param("userId", row.getUserAccountId()).param("viewFull", "yes"), "bt_View.gif"))
         )
     );
 

--- a/web/src/main/java/org/akaza/openclinica/control/login/ChangeStudyServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/login/ChangeStudyServlet.java
@@ -26,6 +26,7 @@ import org.akaza.openclinica.control.admin.StudySubjectStatusStatisticsTableFact
 import org.akaza.openclinica.control.core.SecureController;
 import org.akaza.openclinica.control.form.FormProcessor;
 import org.akaza.openclinica.control.form.Validator;
+import org.akaza.openclinica.control.submit.ListStudySubjectTable;
 import org.akaza.openclinica.control.submit.ListStudySubjectTableFactory;
 import org.akaza.openclinica.dao.login.UserAccountDAO;
 import org.akaza.openclinica.dao.managestudy.DiscrepancyNoteDAO;
@@ -361,23 +362,37 @@ public class ChangeStudyServlet extends SecureController {
 
     private void setupListStudySubjectTable() {
 
-        ListStudySubjectTableFactory factory = new ListStudySubjectTableFactory(true);
-        factory.setStudyEventDefinitionDao(getStudyEventDefinitionDao());
-        factory.setSubjectDAO(getSubjectDAO());
-        factory.setStudySubjectDAO(getStudySubjectDAO());
-        factory.setStudyEventDAO(getStudyEventDAO());
-        factory.setStudyBean(currentStudy);
-        factory.setStudyGroupClassDAO(getStudyGroupClassDAO());
-        factory.setSubjectGroupMapDAO(getSubjectGroupMapDAO());
-        factory.setStudyDAO(getStudyDAO());
-        factory.setCurrentRole(currentRole);
-        factory.setCurrentUser(ub);
-        factory.setEventCRFDAO(getEventCRFDAO());
-        factory.setEventDefintionCRFDAO(getEventDefinitionCRFDAO());
-        factory.setStudyGroupDAO(getStudyGroupDAO());
-        factory.setStudyParameterValueDAO(getStudyParameterValueDAO());
-        String findSubjectsHtml = factory.createTable(request, response).render();
-        request.setAttribute("findSubjectsHtml", findSubjectsHtml);
+        String lcTableRendering = System.getenv("LC_TABLE_RENDERING");
+        // Use JMesa rendering only when LC_TABLE_RENDERING is explicitly set to "jmesa"
+        if (lcTableRendering != null && lcTableRendering.equalsIgnoreCase("jmesa")) {
+            // Legacy JMesa rendering path: unchanged behaviour
+            request.setAttribute("tableRenderingMode", "jmesa");
+            ListStudySubjectTableFactory factory = new ListStudySubjectTableFactory(true);
+            factory.setStudyEventDefinitionDao(getStudyEventDefinitionDao());
+            factory.setSubjectDAO(getSubjectDAO());
+            factory.setStudySubjectDAO(getStudySubjectDAO());
+            factory.setStudyEventDAO(getStudyEventDAO());
+            factory.setStudyBean(currentStudy);
+            factory.setStudyGroupClassDAO(getStudyGroupClassDAO());
+            factory.setSubjectGroupMapDAO(getSubjectGroupMapDAO());
+            factory.setStudyDAO(getStudyDAO());
+            factory.setCurrentRole(currentRole);
+            factory.setCurrentUser(ub);
+            factory.setEventCRFDAO(getEventCRFDAO());
+            factory.setEventDefintionCRFDAO(getEventDefinitionCRFDAO());
+            factory.setStudyGroupDAO(getStudyGroupDAO());
+            factory.setStudyParameterValueDAO(getStudyParameterValueDAO());
+            String findSubjectsHtml = factory.createTable(request, response).render();
+            request.setAttribute("findSubjectsHtml", findSubjectsHtml);
+        } else {
+            // HtmlFlow rendering path
+            request.setAttribute("tableRenderingMode", "htmlflow");
+            ListStudySubjectTable table = new ListStudySubjectTable(getStudySubjectDAO(), getSubjectDAO(), getStudyEventDAO(), getStudyEventDefinitionDao(),
+                getStudyGroupClassDAO(), getSubjectGroupMapDAO(), getStudyGroupDAO(), getStudyDAO(), getEventCRFDAO(), getEventDefinitionCRFDAO(),
+                getStudyParameterValueDAO(), currentStudy, currentRole, ub, locale, session);
+            String findSubjectsHtml = table.render(request);
+            request.setAttribute("findSubjectsHtml", findSubjectsHtml);
+        }
     }
 
     public StudyEventDefinitionDAO getStudyEventDefinitionDao() {

--- a/web/src/main/java/org/akaza/openclinica/control/submit/FindSubjectsRow.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/FindSubjectsRow.java
@@ -1,0 +1,67 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+
+ * For details see: https://libreclinica.org/license
+ * copyright (C) 2026 LibreClinica
+ */
+package org.akaza.openclinica.control.submit;
+
+import org.akaza.openclinica.bean.core.SubjectEventStatus;
+import org.akaza.openclinica.bean.managestudy.StudyEventBean;
+import org.akaza.openclinica.bean.managestudy.StudyEventDefinitionBean;
+import org.akaza.openclinica.bean.managestudy.StudySubjectBean;
+import org.akaza.openclinica.bean.submit.SubjectBean;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Typed row for the "findSubjects" table (LCTable-based {@link ListStudySubjectTable}),
+ * replacing the legacy {@code HashMap<Object,Object>} "pseudo-row" pattern used by
+ * {@code ListStudySubjectTableFactory} (jmesa).
+ */
+public final class FindSubjectsRow {
+
+    public final StudySubjectBean studySubject;
+    public final SubjectBean subject;
+    public final String enrolledAt;                                          // site/study identifier this subject is enrolled at
+    public final boolean isSignable;
+    public final Map<Integer, GroupAssignment> groupAssignmentsByClassId;     // studyGroupClassId -> group assignment (if any)
+    public final Map<Integer, EventColumnData> eventDataByDefinitionId;       // studyEventDefinitionId -> event column data
+
+    public FindSubjectsRow(StudySubjectBean studySubject, SubjectBean subject, String enrolledAt, boolean isSignable,
+            Map<Integer, GroupAssignment> groupAssignmentsByClassId, Map<Integer, EventColumnData> eventDataByDefinitionId) {
+        this.studySubject = studySubject;
+        this.subject = subject;
+        this.enrolledAt = enrolledAt;
+        this.isSignable = isSignable;
+        this.groupAssignmentsByClassId = groupAssignmentsByClassId;
+        this.eventDataByDefinitionId = eventDataByDefinitionId;
+    }
+
+    /** The study-group the subject is assigned to, within a given study-group-class. */
+    public static final class GroupAssignment {
+        public final Integer groupId;
+        public final String groupName;
+
+        public GroupAssignment(Integer groupId, String groupName) {
+            this.groupId = groupId;
+            this.groupName = groupName;
+        }
+    }
+
+    /** Aggregate status + occurrences for one study-event-definition column, for one subject. */
+    public static final class EventColumnData {
+        public final SubjectEventStatus aggregateStatus;   // status of the first occurrence, or NOT_SCHEDULED if none
+        public final List<StudyEventBean> occurrences;
+        public final StudyEventDefinitionBean definition;
+
+        public EventColumnData(SubjectEventStatus aggregateStatus, List<StudyEventBean> occurrences, StudyEventDefinitionBean definition) {
+            this.aggregateStatus = aggregateStatus;
+            this.occurrences = occurrences;
+            this.definition = definition;
+        }
+    }
+
+}

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTable.java
@@ -1,0 +1,638 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+
+ * For details see: https://libreclinica.org/license
+ * copyright (C) 2026 LibreClinica
+ */
+package org.akaza.openclinica.control.submit;
+
+import org.akaza.openclinica.bean.core.Role;
+import org.akaza.openclinica.bean.core.Status;
+import org.akaza.openclinica.bean.core.SubjectEventStatus;
+import org.akaza.openclinica.bean.login.StudyUserRoleBean;
+import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.bean.managestudy.StudyBean;
+import org.akaza.openclinica.bean.managestudy.StudyEventBean;
+import org.akaza.openclinica.bean.managestudy.StudyEventDefinitionBean;
+import org.akaza.openclinica.bean.managestudy.StudyGroupBean;
+import org.akaza.openclinica.bean.managestudy.StudyGroupClassBean;
+import org.akaza.openclinica.bean.managestudy.StudySubjectBean;
+import org.akaza.openclinica.bean.submit.EventCRFBean;
+import org.akaza.openclinica.bean.submit.SubjectBean;
+import org.akaza.openclinica.bean.submit.SubjectGroupMapBean;
+import org.akaza.openclinica.control.submit.FindSubjectsRow.EventColumnData;
+import org.akaza.openclinica.control.submit.FindSubjectsRow.GroupAssignment;
+import org.akaza.openclinica.dao.managestudy.EventDefinitionCRFDAO;
+import org.akaza.openclinica.dao.managestudy.FindSubjectsFilter;
+import org.akaza.openclinica.dao.managestudy.FindSubjectsSort;
+import org.akaza.openclinica.dao.managestudy.StudyDAO;
+import org.akaza.openclinica.dao.managestudy.StudyEventDAO;
+import org.akaza.openclinica.dao.managestudy.StudyEventDefinitionDAO;
+import org.akaza.openclinica.dao.managestudy.StudyGroupClassDAO;
+import org.akaza.openclinica.dao.managestudy.StudyGroupDAO;
+import org.akaza.openclinica.dao.managestudy.StudySubjectDAO;
+import org.akaza.openclinica.dao.service.StudyParameterValueDAO;
+import org.akaza.openclinica.dao.submit.EventCRFDAO;
+import org.akaza.openclinica.dao.submit.SubjectDAO;
+import org.akaza.openclinica.dao.submit.SubjectGroupMapDAO;
+import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+import org.akaza.openclinica.lctable.*;
+import org.akaza.openclinica.service.pmanage.ParticipantPortalRegistrar;
+import org.xmlet.htmlapifaster.Div;
+import org.xmlet.htmlapifaster.Element;
+import org.xmlet.htmlapifaster.Td;
+
+import static org.akaza.openclinica.lctable.LCTableColumnDef.*;
+import static org.akaza.openclinica.lctable.LCTableFilterDef.*;
+import static org.akaza.openclinica.lctable.LCTableUtil.*;
+import static org.akaza.openclinica.lctable.SafeUrl.url;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+
+/**
+ * LCTable-based rendering of the "findSubjects" table (Subject Matrix grid).
+ * Dynamically builds columns for study groups and event definitions, handles subject status,
+ * and renders event occurrence details in popup menus.
+ */
+public class ListStudySubjectTable {
+
+    private static final Map<Integer, String> EVENT_STATUS_ICON_PATHS = new HashMap<>();
+    static {
+        EVENT_STATUS_ICON_PATHS.put(1, "images/icon_Scheduled.gif");
+        EVENT_STATUS_ICON_PATHS.put(2, "images/icon_NotStarted.gif");
+        EVENT_STATUS_ICON_PATHS.put(3, "images/icon_InitialDE.gif");
+        EVENT_STATUS_ICON_PATHS.put(4, "images/icon_DEcomplete.gif");
+        EVENT_STATUS_ICON_PATHS.put(5, "images/icon_Stopped.gif");
+        EVENT_STATUS_ICON_PATHS.put(6, "images/icon_Skipped.gif");
+        EVENT_STATUS_ICON_PATHS.put(7, "images/icon_Locked.gif");
+        EVENT_STATUS_ICON_PATHS.put(8, "images/icon_Signed.gif");
+    }
+
+    private final StudySubjectDAO studySubjectDAO;
+    private final SubjectDAO subjectDAO;
+    private final StudyEventDAO studyEventDAO;
+    private final StudyGroupClassDAO studyGroupClassDAO;
+    private final SubjectGroupMapDAO subjectGroupMapDAO;
+    private final StudyGroupDAO studyGroupDAO;
+    private final StudyDAO studyDAO;
+    private final EventCRFDAO eventCRFDAO;
+    private final EventDefinitionCRFDAO eventDefinitionCRFDAO;
+    private final StudyParameterValueDAO studyParameterValueDAO;
+
+    private final StudyBean studyBean;
+    private final StudyUserRoleBean currentRole;
+    private final UserAccountBean currentUser;
+    private final HttpSession session;         // for participant portal status caching
+
+    private final ResourceBundle resword;
+    private final ResourceBundle resformat;    // for date formatting in event popups
+
+    private final List<StudyGroupClassBean> studyGroupClasses;
+    private final List<StudyEventDefinitionBean> studyEventDefinitions;
+
+    private final LCTable<FindSubjectsRow> table;
+
+    public ListStudySubjectTable(StudySubjectDAO studySubjectDAO, SubjectDAO subjectDAO, StudyEventDAO studyEventDAO,
+            StudyEventDefinitionDAO studyEventDefinitionDAO, StudyGroupClassDAO studyGroupClassDAO, SubjectGroupMapDAO subjectGroupMapDAO,
+            StudyGroupDAO studyGroupDAO, StudyDAO studyDAO, EventCRFDAO eventCRFDAO, EventDefinitionCRFDAO eventDefinitionCRFDAO,
+            StudyParameterValueDAO studyParameterValueDAO, StudyBean studyBean, StudyUserRoleBean currentRole, UserAccountBean currentUser,
+            Locale locale, HttpSession session) {
+        this.studySubjectDAO = studySubjectDAO;
+        this.subjectDAO = subjectDAO;
+        this.studyEventDAO = studyEventDAO;
+        this.studyGroupClassDAO = studyGroupClassDAO;
+        this.subjectGroupMapDAO = subjectGroupMapDAO;
+        this.studyGroupDAO = studyGroupDAO;
+        this.studyDAO = studyDAO;
+        this.eventCRFDAO = eventCRFDAO;
+        this.eventDefinitionCRFDAO = eventDefinitionCRFDAO;
+        this.studyParameterValueDAO = studyParameterValueDAO;
+        this.studyBean = studyBean;
+        this.currentRole = currentRole;
+        this.currentUser = currentUser;
+        this.session = session;
+        this.resword = ResourceBundleProvider.getWordsBundle(locale);
+        this.resformat = ResourceBundleProvider.getFormatBundle(locale);
+
+        // sites inherit their parent study's group-classes/event-definitions
+        int parentStudyId = studyBean.getParentStudyId();
+        if (parentStudyId > 0) {
+            StudyBean parentStudy = studyDAO.findByPK(parentStudyId);
+            this.studyGroupClasses = studyGroupClassDAO.findAllActiveByStudy(parentStudy);
+            this.studyEventDefinitions = studyEventDefinitionDAO.findAllActiveByParentStudyId(parentStudy.getId());
+        } else {
+            this.studyGroupClasses = studyGroupClassDAO.findAllActiveByStudy(studyBean);
+            this.studyEventDefinitions = studyEventDefinitionDAO.findAllActiveByParentStudyId(studyBean.getId());
+        }
+
+        this.table = new LCTable<>("findSubjects", buildColumns(), this::fetchData);
+        this.table.addCustomToolbarControl(this::renderSelectEventControl);
+        if (isAddSubjectLinkShown()) {
+            this.table.addCustomToolbarControl(this::renderAddNewSubjectControl);
+        }
+    }
+
+    private boolean isAddSubjectLinkShown() {
+        return studyBean.getStatus() == Status.AVAILABLE && currentRole.getRole() != Role.MONITOR;
+    }
+
+    // -- Element ID helpers (uses database PKs for stable IDs) -------------------------------------
+
+    /** Id for a row-level action link in the "Actions" column (view/remove/restore/reassign/sign/...). */
+    private static String actionId(String action, int studySubjectId) {
+        return "findSubjects-" + action + "-" + studySubjectId;
+    }
+
+    /** ID for definition-level event actions (e.g. "Schedule" or "Add another occurrence"). */
+    private static String eventActionId(String action, int studySubjectId, int sedId) {
+        return "findSubjects-" + action + "-event-" + studySubjectId + "-" + sedId;
+    }
+
+    /** Id for an action tied to one specific event occurrence (view/edit/remove an occurrence). */
+    private static String occurrenceActionId(String action, int occurrenceId) {
+        return "findSubjects-" + action + "-occurrence-" + occurrenceId;
+    }
+
+    /** Toolbar dropdown to navigate to {@code ListEventsForSubjects} for a selected event definition. */
+    private void renderSelectEventControl(Div<?> container, LCTableContext<FindSubjectsRow> ctx) {
+        container.div().attrClass("dropdown-list")
+            .of(div -> {
+                div.label().text("").__();
+                div.select()
+                    .addAttr("onchange",
+                        "var v=this.value; if (v) { window.location='" + ctx.resourcePath
+                            + "/ListEventsForSubjects?module=submit&defId=' + v; }")
+                    .of(select -> {
+                        select.option().attrValue("").text(resword.getString("select_an_event")).__();
+                        for (StudyEventDefinitionBean sed : studyEventDefinitions) {
+                            select.option().attrValue(String.valueOf(sed.getId())).text(sed.getName()).__();
+                        }
+                    })
+                    .__();
+            })
+            .__();
+    }
+
+    /** Toolbar button opening the "Add New Subject" modal. */
+    private void renderAddNewSubjectControl(Div<?> container, LCTableContext<FindSubjectsRow> ctx) {
+        container.a().attrClass("text-btn").attrHref("javascript:;").attrId("addSubject")
+            .text(resword.getString("add_new_subject"))
+            .__();
+    }
+
+    // -- Column definitions ----------------------------------------------------------------------
+
+    private List<LCTableColumnDef<FindSubjectsRow>> buildColumns() {
+        List<LCTableColumnDef<FindSubjectsRow>> columns = new ArrayList<>();
+
+        columns.add(textCol("studySubject.label", resword.getString("study_subject_ID"), 6, row -> row.studySubject.getLabel()));
+        columns.add(enumColHidden("studySubject.status", resword.getString("subject_status"), 6,
+            row -> row.studySubject.getStatus(), Status.toDropDownArrayList(), Status::getName, Status::getName
+        ));
+        columns.add(textColHidden("enrolledAt", resword.getString("site_id"), 5, row -> row.enrolledAt));
+        columns.add(textColHidden("studySubject.oid", resword.getString("rule_oid"), 6, row -> row.studySubject.getOid()));
+        columns.add(new LCTableColumnDef<>("subject.charGender", resword.getString("gender"), 3, HIDDEN, NOT_SORTABLE, textFilter(),
+            LCTableColumnDef.<FindSubjectsRow>nullSafeColText(row -> String.valueOf(row.subject.getGender()))
+        ));
+        columns.add(textColHidden("studySubject.secondaryLabel", resword.getString("secondary_ID"), 5, row -> row.studySubject.getSecondaryLabel()));
+        columns.add(textColHidden("subject.uniqueIdentifier", resword.getString("subject_unique_ID"), 6, row -> row.subject.getUniqueIdentifier()));
+
+        // one column per active study-group-class
+        for (StudyGroupClassBean sgc : studyGroupClasses) {
+            List<StudyGroupBean> groupOptions = studyGroupDAO.findAllByGroupClass(sgc);
+            columns.add(enumColNotSortable("sgc_" + sgc.getId(), sgc.getName(), 6, groupOptions, StudyGroupBean::getName, StudyGroupBean::getName,
+                row -> {
+                    GroupAssignment ga = row.groupAssignmentsByClassId.get(sgc.getId());
+                    return ga == null ? "" : ga.groupName;
+                }
+            ));
+        }
+
+        // one column per active study-event-definition
+        for (StudyEventDefinitionBean sed : studyEventDefinitions) {
+            columns.add(customTdCol("sed_" + sed.getId(), sed.getName(), 6, NOT_SORTABLE,
+                // SubjectEventStatus.getName() (Term.getName()) already resolves the translated display name via
+                // the terms resource bundle -- do NOT re-translate it here (that would look up the translated text
+                // itself as if it were a resource key, throwing MissingResourceException).
+                new LCTableFilterDef.Select<>(SubjectEventStatus.toArrayList(), SubjectEventStatus::getName, SubjectEventStatus::getName),
+                (td, row) -> renderEventCell(td, row, row.eventDataByDefinitionId.get(sed.getId()))
+            ));
+        }
+
+        columns.add(customTdCol("actions", resword.getString("rule_actions"), 10, NOT_SORTABLE, clearFilter(),
+            this::renderActionsCell
+        ));
+
+        return columns;
+    }
+
+    /** Renders an event definition cell with status icon(s) and a hover/focus popup for event occurrence details (see {@link #renderEventPopup}). */
+    private void renderEventCell(Td<?> td, FindSubjectsRow row, EventColumnData data) {
+        if (data == null) {
+            td.text("");
+            return;
+        }
+        List<StudyEventBean> occurrences = data.occurrences == null ? Collections.emptyList() : data.occurrences;
+
+        td.div().attrClass("event-trigger lc-popup-trigger").addAttr("tabindex", "0")
+            .of(trigger -> {
+                renderStatusIcons(trigger, data.aggregateStatus, occurrences);
+                renderEventPopup(trigger, row.studySubject, data.definition, data.aggregateStatus, occurrences);
+            })
+            .__();
+    }
+
+    /** Renders an icon and count badge for each distinct status present across occurrences. */
+    private <T extends Element<?, ?>> void renderStatusIcons(Div<T> trigger, SubjectEventStatus aggregateStatus, List<StudyEventBean> occurrences) {
+        if (occurrences.isEmpty()) {
+            renderStatusBadge(trigger, aggregateStatus, 0, false);
+            return;
+        }
+        boolean showCounts = occurrences.size() > 1;
+        Map<Integer, Long> countByStatusId = occurrences.stream()
+            .collect(Collectors.groupingBy(o -> o.getSubjectEventStatus().getId(), Collectors.counting()));
+        // iterate in the same fixed, deterministic order used for the column's filter dropdown
+        for (SubjectEventStatus status : SubjectEventStatus.toArrayList()) {
+            Long count = countByStatusId.get(status.getId());
+            if (count != null) {
+                renderStatusBadge(trigger, status, count.intValue(), showCounts);
+            }
+        }
+    }
+
+    private <T extends Element<?, ?>> void renderStatusBadge(Div<T> trigger, SubjectEventStatus status, int count, boolean showCount) {
+        String iconPath = EVENT_STATUS_ICON_PATHS.get(status.getId());
+        trigger.span().attrClass("event-status-badge")
+            .of(badge -> {
+                if (iconPath != null) {
+                    badge.img().attrSrc(iconPath).attrAlt(status.getName()).__();
+                }
+                if (showCount) {
+                    badge.text(" x" + count);
+                }
+            })
+            .__();
+    }
+
+    /** Renders the hover/focus popup showing subject/event header and scrolling occurrence list. */
+    private <T extends Element<?, ?>> void renderEventPopup(Div<T> trigger, StudySubjectBean studySubject,
+                                                            StudyEventDefinitionBean sed, SubjectEventStatus aggregateStatus, List<StudyEventBean> occurrences) {
+        Status subjectStatus = studySubject.getStatus();
+        boolean canAddOccurrence = sed.isRepeating() && !occurrences.isEmpty()
+            && subjectStatus != Status.DELETED && subjectStatus != Status.AUTO_DELETED
+            && studyBean.getStatus() == Status.AVAILABLE;
+        String addOccurrenceHref = "CreateNewStudyEvent?studySubjectId=" + studySubject.getId() + "&studyEventDefinition=" + sed.getId();
+
+        trigger.div().attrClass("event-popup lc-popup ViewSubjectsPopup")
+            .of(popup -> {
+                popup.div().attrClass("event-popup-header table_header_row_left")
+                    .of(header -> {
+                        header.div().attrClass("event-popup-header-text")
+                            .text(resword.getString("subject") + ": " + studySubject.getLabel())
+                            .br().__()
+                            .text(resword.getString("event") + ": " + sed.getName())
+                            .__();
+                        if (canAddOccurrence) {
+                            header.a().attrClass("text-btn").attrHref(addOccurrenceHref)
+                                .attrId(eventActionId("add-occurrence", studySubject.getId(), sed.getId()))
+                                .text(resword.getString("add_another_occurrence"))
+                                .__();
+                        }
+                    })
+                    .__();
+                popup.div().attrClass("event-popup-body")
+                    .of(body -> renderPopupBody(body, studySubject, sed, aggregateStatus, occurrences))
+                    .__();
+            })
+            .__();
+    }
+
+    private <T extends Element<?, ?>> void renderPopupBody(Div<T> body, StudySubjectBean studySubject, StudyEventDefinitionBean sed,
+                                                           SubjectEventStatus aggregateStatus, List<StudyEventBean> occurrences) {
+        if (occurrences.isEmpty()) {
+            body.div().attrClass("event-occurrence-row")
+                .of(row -> {
+                    row.div().attrClass("table_cell_left")
+                        .of(line -> renderStatusLine(line, aggregateStatus))
+                        .__();
+                    if (currentRole.getRole() != Role.MONITOR && !studyBean.getStatus().isFrozen()) {
+                        row.div().attrClass("table_cell_left occurrence-actions occurrence-actions-vertical")
+                            .of(actions -> actions.of(actionLink(eventActionId("schedule", studySubject.getId(), sed.getId()), resword.getString("schedule"),
+                                url("CreateNewStudyEvent").param("studySubjectId", studySubject.getId()).param("studyEventDefinition", sed.getId()),
+                                "bt_Schedule.gif", true)))
+                            .__();
+                    }
+                })
+                .__();
+            return;
+        }
+        int total = occurrences.size();
+        for (int i = 0; i < total; i++) {
+            StudyEventBean occurrence = occurrences.get(i);
+            if (sed.isRepeating()) {
+                renderRepeatingOccurrenceRow(body, studySubject, occurrence, i + 1, total);
+            } else {
+                renderSimpleOccurrenceRow(body, studySubject, occurrence);
+            }
+        }
+    }
+
+    /** Vertical layout for non-repeating events and unpopulated occurrences (icon + text label). */
+    private <T extends Element<?, ?>> void renderSimpleOccurrenceRow(Div<T> body, StudySubjectBean studySubject, StudyEventBean occurrence) {
+        body.div().attrClass("event-occurrence-row")
+            .of(row -> {
+                String date = formatDate(occurrence.getDateStarted());
+                if (!date.isEmpty()) {
+                    row.div().attrClass("table_cell_left").text(date).__();
+                }
+                row.div().attrClass("table_cell_left")
+                    .of(line -> renderStatusLine(line, occurrence.getSubjectEventStatus()))
+                    .__();
+                row.div().attrClass("table_cell_left occurrence-actions occurrence-actions-vertical")
+                    .of(actions -> renderOccurrenceActions(actions, studySubject, occurrence, true))
+                    .__();
+            })
+            .__();
+    }
+
+    /** Compact two-line layout for repeating event occurrences. */
+    private <T extends Element<?, ?>> void renderRepeatingOccurrenceRow(Div<T> body, StudySubjectBean studySubject, StudyEventBean occurrence,
+                                                                        int occNumber, int total) {
+        body.div().attrClass("event-occurrence-row event-occurrence-row-compact")
+            .of(row -> {
+                row.div().attrClass("table_cell_left occurrence-summary-line")
+                    .of(line -> {
+                        String date = formatDate(occurrence.getDateStarted());
+                        line.text(resword.getString("ocurrence") + " #" + occNumber + " of " + total + " \u00B7 ");
+                        if (!date.isEmpty()) {
+                            line.text(date + " \u00B7 ");
+                        }
+                        line.text(resword.getString("status") + ": ");
+                        renderStatusIconAndText(line, occurrence.getSubjectEventStatus());
+                    })
+                    .__();
+                row.div().attrClass("table_cell_left occurrence-actions occurrence-actions-compact")
+                    .of(actions -> {
+                        actions.text(resword.getString("rule_actions") + ": ");
+                        renderOccurrenceActions(actions, studySubject, occurrence, false);
+                    })
+                    .__();
+            })
+            .__();
+    }
+
+    /** Renders "Status: [icon] text", used by both the simple and compact occurrence-row layouts. */
+    private <T extends Element<?, ?>> void renderStatusLine(Div<T> line, SubjectEventStatus status) {
+        line.text(resword.getString("status") + ": ");
+        renderStatusIconAndText(line, status);
+    }
+
+    /** Renders the status icon (if any) immediately followed by the status's display text. */
+    private <T extends Element<?, ?>> void renderStatusIconAndText(Div<T> container, SubjectEventStatus status) {
+        String iconPath = EVENT_STATUS_ICON_PATHS.get(status.getId());
+        if (iconPath != null) {
+            container.img().attrClass("event-status-icon-inline").attrSrc(iconPath).attrAlt(status.getName()).__();
+        }
+        container.text(" " + status.getName());
+    }
+
+    /**
+     * Renders view/edit/remove action links for an event occurrence.
+     *
+     * @param includeText if true, renders icon + text label; if false, renders icon-only links.
+     */
+    private <T extends Element<?, ?>> void renderOccurrenceActions(Div<T> actions, StudySubjectBean studySubject, StudyEventBean occurrence,
+                                                                   boolean includeText) {
+        Status eventSysStatus = studySubject.getStatus();
+        SubjectEventStatus eventStatus = occurrence.getSubjectEventStatus();
+        String studyEventId = String.valueOf(occurrence.getId());
+        String view = resword.getString("view") + "/" + resword.getString("enter_data");
+        boolean studyDirectorOrSysAdmin = currentRole.getRole() == Role.STUDYDIRECTOR || currentUser.isSysAdmin();
+        boolean studyAvailable = studyBean.getStatus() == Status.AVAILABLE;
+
+        if (eventSysStatus == Status.DELETED || eventSysStatus == Status.AUTO_DELETED) {
+            actions.of(actionLink(occurrenceActionId("view", occurrence.getId()), view, url("EnterDataForStudyEvent").param("eventId", studyEventId), "bt_View.gif", includeText));
+            return;
+        }
+        if (eventSysStatus.getId() != Status.AVAILABLE.getId() && eventSysStatus != Status.SIGNED) {
+            return;
+        }
+        if (eventStatus == SubjectEventStatus.LOCKED) {
+            if (studyDirectorOrSysAdmin) {
+                actions.of(actionLink(occurrenceActionId("view", occurrence.getId()), view, url("EnterDataForStudyEvent").param("eventId", studyEventId), "bt_View.gif", includeText));
+                if (studyAvailable) {
+                    actions.of(actionLink(occurrenceActionId("remove", occurrence.getId()), resword.getString("remove"),
+                        url("RemoveStudyEvent").param("action", "confirm").param("id", studyEventId).param("studySubId", studySubject.getId()),
+                        "bt_Remove.gif", includeText));
+                }
+            }
+            return;
+        }
+        actions.of(actionLink(occurrenceActionId("view", occurrence.getId()), view, url("EnterDataForStudyEvent").param("eventId", studyEventId), "bt_View.gif", includeText));
+        if (studyDirectorOrSysAdmin && studyAvailable) {
+            actions.of(actionLink(occurrenceActionId("edit", occurrence.getId()), resword.getString("edit"),
+                url("UpdateStudyEvent").param("event_id", studyEventId).param("ss_id", studySubject.getId()), "bt_Edit.gif", includeText));
+            actions.of(actionLink(occurrenceActionId("remove", occurrence.getId()), resword.getString("remove"),
+                url("RemoveStudyEvent").param("action", "confirm").param("id", studyEventId).param("studySubId", studySubject.getId()), "bt_Remove.gif", includeText));
+        }
+    }
+
+    private String formatDate(java.util.Date date) {
+        if (date == null) return "";
+        return new SimpleDateFormat(resformat.getString("date_format_string")).format(date);
+    }
+
+    private void renderActionsCell(Td<?> td, FindSubjectsRow row) {
+        StudySubjectBean studySubject = row.studySubject;
+        if (studySubject.getId() == 0) {
+            return;
+        }
+        td.of(actionLink(actionId("view", studySubject.getId()), resword.getString("view"), url("ViewStudySubject").param("id", studySubject.getId()), "bt_View.gif"));
+
+        if (currentRole.getRole() == Role.MONITOR) {
+            return;
+        }
+
+        boolean studyAvailable = studyBean.getStatus() == Status.AVAILABLE;
+        boolean subjectDeleted = studySubject.getStatus() == Status.DELETED || studySubject.getStatus() == Status.AUTO_DELETED;
+
+        if (studyAvailable && !subjectDeleted && currentRole.getRole() != Role.RESEARCHASSISTANT && currentRole.getRole() != Role.RESEARCHASSISTANT2) {
+            td.of(actionLink(actionId("remove", studySubject.getId()), resword.getString("remove"),
+                url("RemoveStudySubject").param("action", "confirm").param("id", studySubject.getId()).param("subjectId", studySubject.getSubjectId()).param("studyId", studySubject.getStudyId()),
+                "bt_Remove.gif"));
+        }
+        if (studyAvailable && subjectDeleted) {
+            td.of(actionLink(actionId("restore", studySubject.getId()), resword.getString("restore"),
+                url("RestoreStudySubject").param("action", "confirm").param("id", studySubject.getId()).param("subjectId", studySubject.getSubjectId()).param("studyId", studySubject.getStudyId()),
+                "bt_Restore.gif"));
+        }
+        if (studyAvailable && currentRole.getRole() != Role.RESEARCHASSISTANT && currentRole.getRole() != Role.RESEARCHASSISTANT2
+            && currentRole.getRole() != Role.INVESTIGATOR && studySubject.getStatus() == Status.AVAILABLE) {
+            td.of(actionLink(actionId("reassign", studySubject.getId()), resword.getString("reassign"), url("ReassignStudySubject").param("id", studySubject.getId()), "bt_Reassign.gif"));
+        }
+        if (currentRole.getRole() == Role.INVESTIGATOR && studyAvailable && studySubject.getStatus() != Status.DELETED && row.isSignable) {
+            td.of(actionLink(actionId("sign", studySubject.getId()), resword.getString("sign"), url("SignStudySubject").param("id", studySubject.getId()), "icon_Signed.gif"));
+        }
+        try {
+            if (studyAvailable && (currentRole.getRole() == Role.RESEARCHASSISTANT || currentRole.getRole() == Role.RESEARCHASSISTANT2)
+                && studySubject.getStatus() == Status.AVAILABLE && "ACTIVE".equalsIgnoreCase(pManageStatus(studySubject))
+                && "enabled".equalsIgnoreCase(participateStatus(studySubject))) {
+                td.of(actionLink(actionId("connect-participant", studySubject.getId()), resword.getString("connect_participant"), participateUrl(studySubject), "bt_Ocui.gif"));
+            }
+        } catch (Exception e) {
+            // matches legacy behaviour: silently omit the "connect participant" link on any failure
+        }
+    }
+
+    // -- Participant-portal helpers (ported as-is from ListStudySubjectTableFactory) ------------------
+
+    private String participateStatus(StudySubjectBean studySubject) {
+        StudyBean study = studyDAO.findByPK(studySubject.getStudyId());
+        StudyBean pStudy = getParentStudy(study.getOid());
+        return studyParameterValueDAO.findByHandleAndStudy(pStudy.getId(), "participantPortal").getValue();
+    }
+
+    private String pManageStatus(StudySubjectBean studySubject) throws Exception {
+        StudyBean study = studyDAO.findByPK(studySubject.getStudyId());
+        StudyBean pStudy = getParentStudy(study.getOid());
+        return new ParticipantPortalRegistrar().getCachedRegistrationStatus(pStudy.getOid(), session);
+    }
+
+    private SafeUrl participateUrl(StudySubjectBean studySubject) throws Exception {
+        StudyBean study = studyDAO.findByPK(studySubject.getStudyId());
+        StudyBean pStudy = getParentStudy(study.getOid());
+        String hostUrl = new ParticipantPortalRegistrar().getStudyHost(pStudy.getOid());
+        return url(hostUrl).param("ssid", studySubject.getLabel());
+    }
+
+    private StudyBean getParentStudy(String studyOid) {
+        StudyBean study = studyDAO.findByOid(studyOid);
+        return study.getParentStudyId() == 0 ? study : studyDAO.findByPK(study.getParentStudyId());
+    }
+
+    // -- Data fetching -----------------------------------------------------------------------------
+
+    private LCTableData<FindSubjectsRow> fetchData(LCTableParams p) {
+        FindSubjectsFilter filter = buildFilter(p);
+        FindSubjectsSort sort = buildSort(p);
+
+        int rowStart = p.page * p.maxRows;
+        int rowEnd = rowStart + p.maxRows;
+        List<StudySubjectBean> studySubjects = studySubjectDAO.getWithFilterAndSort(studyBean, filter, sort, rowStart, rowEnd);
+        int total = studySubjectDAO.getCountWithFilter(filter, studyBean);
+
+        List<FindSubjectsRow> rows = new ArrayList<>();
+        for (StudySubjectBean studySubject : studySubjects) {
+            rows.add(buildRow(studySubject));
+        }
+        return new LCTableData<>(rows, total);
+    }
+
+    private FindSubjectsFilter buildFilter(LCTableParams p) {
+        FindSubjectsFilter filter = new FindSubjectsFilter();
+        p.filters.forEach((property, value) -> {
+            if ("studySubject.status".equals(property)) {
+                filter.addFilter(property, Status.getByName(value).getId() + "");
+            } else if (property.startsWith("sgc_")) {
+                int studyGroupClassId = Integer.parseInt(property.substring(4));
+                StudyGroupBean group = studyGroupDAO.findByNameAndGroupClassID(value, studyGroupClassId);
+                filter.addFilter(property, group.getId() + "");
+            } else {
+                // includes sed_* (FindSubjectsFilter itself resolves the translated status name to its id)
+                // and the plain free-text columns (studySubject.label, enrolledAt, studySubject.oid,
+                // subject.charGender, studySubject.secondaryLabel, subject.uniqueIdentifier)
+                filter.addFilter(property, value);
+            }
+        });
+        return filter;
+    }
+
+    private FindSubjectsSort buildSort(LCTableParams p) {
+        FindSubjectsSort sort = new FindSubjectsSort();
+        if (p.sortProp != null && !p.sortProp.isEmpty()) {
+            sort.addSort(p.sortProp, p.sortDir == null ? "asc" : p.sortDir);
+        }
+        return sort;
+    }
+
+    private FindSubjectsRow buildRow(StudySubjectBean studySubject) {
+        String enrolledAt = (studyDAO.findByPK(studySubject.getStudyId())).getIdentifier();
+        SubjectBean subject = subjectDAO.findByPK(studySubject.getSubjectId());
+
+        List<StudyEventBean> allStudyEvents = studyEventDAO.findAllByStudySubject(studySubject);
+        Map<Integer, List<StudyEventBean>> studyEventsBySedId = new HashMap<>();
+        for (StudyEventBean studyEventBean : allStudyEvents) {
+            studyEventsBySedId.computeIfAbsent(studyEventBean.getStudyEventDefinitionId(), k -> new ArrayList<>()).add(studyEventBean);
+        }
+
+        Map<Integer, GroupAssignment> groupAssignmentsByClassId = new HashMap<>();
+        for (StudyGroupClassBean sgc : studyGroupClasses) {
+            SubjectGroupMapBean sgm = subjectGroupMapDAO.findByStudySubjectAndStudyGroupClass(studySubject.getId(), sgc.getId());
+            if (sgm != null) {
+                groupAssignmentsByClassId.put(sgc.getId(), new GroupAssignment(sgm.getStudyGroupId(), sgm.getStudyGroupName()));
+            }
+        }
+
+        Map<Integer, EventColumnData> eventDataByDefinitionId = new HashMap<>();
+        for (StudyEventDefinitionBean sed : studyEventDefinitions) {
+            List<StudyEventBean> studyEvents = studyEventsBySedId.getOrDefault(sed.getId(), new ArrayList<>());
+            SubjectEventStatus aggregateStatus = SubjectEventStatus.NOT_SCHEDULED;
+            for (StudyEventBean studyEventBean : studyEvents) {
+                if (studyEventBean.getSampleOrdinal() == 1) {
+                    aggregateStatus = studyEventBean.getSubjectEventStatus();
+                    break;
+                }
+            }
+            eventDataByDefinitionId.put(sed.getId(), new EventColumnData(aggregateStatus, studyEvents, sed));
+        }
+
+        boolean isSignable = isSignable(allStudyEvents, studySubject);
+
+        return new FindSubjectsRow(studySubject, subject, enrolledAt, isSignable, groupAssignmentsByClassId, eventDataByDefinitionId);
+    }
+
+    private boolean isSignable(List<StudyEventBean> allStudyEvents, StudySubjectBean studySubject) {
+        if (studySubject.getStatus().isSigned()) {
+            return false;
+        }
+        for (StudyEventBean studyEventBean : allStudyEvents) {
+            if (studyEventBean.getSubjectEventStatus() == SubjectEventStatus.DATA_ENTRY_STARTED
+                || studyEventBean.getSubjectEventStatus() == SubjectEventStatus.SCHEDULED) {
+                return false;
+            }
+            if (eventHasRequiredUncompleteCRFs(studyEventBean)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean eventHasRequiredUncompleteCRFs(StudyEventBean studyEventBean) {
+        List<EventCRFBean> eventCRFs = eventCRFDAO.findAllByStudyEvent(studyEventBean);
+        for (EventCRFBean crfBean : eventCRFs) {
+            if (crfBean != null && crfBean.getCompletionStatusId() == 0 && eventDefinitionCRFDAO.isRequiredInDefinition(crfBean.getCRFVersionId(), studyEventBean)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // -- Rendering entry point ---------------------------------------------------------------------
+
+    public String render(HttpServletRequest request) {
+        final LCTableParams params = new LCTableParams(request.getQueryString(), this.table);
+        return this.table.render(request.getRequestURI(), params, request.getContextPath());
+    }
+
+}

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectsServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectsServlet.java
@@ -112,7 +112,7 @@ public class ListStudySubjectsServlet extends SecureController {
         if (fp.getString("navBar").equals("yes") && fp.getString("findSubjects_f_studySubject.label").trim().length() > 0) {
             StudySubjectBean studySubject = getStudySubjectDAO().findByLabelAndStudy(fp.getString("findSubjects_f_studySubject.label"), currentStudy);
             if (studySubject.getId() > 0) {
-                request.setAttribute("id", new Integer(studySubject.getId()).toString());
+                request.setAttribute("id", Integer.toString(studySubject.getId()));
                 forwardPage(Page.VIEW_STUDY_SUBJECT_SERVLET);
             } else {
                 createTable();
@@ -125,32 +125,60 @@ public class ListStudySubjectsServlet extends SecureController {
 
     private void createTable() {
 
-        ListStudySubjectTableFactory factory = new ListStudySubjectTableFactory(showMoreLink);
-        factory.setStudyEventDefinitionDao(getStudyEventDefinitionDao());
-        factory.setSubjectDAO(getSubjectDAO());
-        factory.setStudySubjectDAO(getStudySubjectDAO());
-        factory.setStudyEventDAO(getStudyEventDAO());
-        factory.setStudyBean(currentStudy);
-        factory.setStudyGroupClassDAO(getStudyGroupClassDAO());
-        factory.setSubjectGroupMapDAO(getSubjectGroupMapDAO());
-        factory.setStudyDAO(getStudyDAO());
-        factory.setCurrentRole(currentRole);
-        factory.setCurrentUser(ub);
-        factory.setEventCRFDAO(getEventCRFDAO());
-        factory.setEventDefintionCRFDAO(getEventDefinitionCRFDAO());
-        factory.setStudyGroupDAO(getStudyGroupDAO());
-        factory.setStudyParameterValueDAO(getStudyParameterValueDAO());
-        String findSubjectsHtml = factory.createTable(request, response).render();
-
-        request.setAttribute("findSubjectsHtml", findSubjectsHtml);
-        // A. Hamid.
-        // For event definitions and group class list in the add subject popup
+        // For event definitions and group class list in the add subject popup (imported addNewSubjectExpressNew.jsp).
         request.setAttribute("allDefsArray", super.getEventDefinitionsByCurrentStudy());
         request.setAttribute("studyGroupClasses", super.getStudyGroupClassesByCurrentStudy());
         FormDiscrepancyNotes discNotes = new FormDiscrepancyNotes();
         session.setAttribute(AddNewSubjectServlet.FORM_DISCREPANCY_NOTES_NAME, discNotes);
 
-        forwardPage(Page.LIST_STUDY_SUBJECTS);
+        String lcTableRendering = System.getenv("LC_TABLE_RENDERING");
+        // Use JMesa rendering only when LC_TABLE_RENDERING is explicitly set to "jmesa"
+        if (lcTableRendering != null && lcTableRendering.equalsIgnoreCase("jmesa")) {
+            // Legacy JMesa rendering path: unchanged behaviour (render and forward)
+            request.setAttribute("tableRenderingMode", "jmesa");
+            ListStudySubjectTableFactory factory = new ListStudySubjectTableFactory(showMoreLink);
+            factory.setStudyEventDefinitionDao(getStudyEventDefinitionDao());
+            factory.setSubjectDAO(getSubjectDAO());
+            factory.setStudySubjectDAO(getStudySubjectDAO());
+            factory.setStudyEventDAO(getStudyEventDAO());
+            factory.setStudyBean(currentStudy);
+            factory.setStudyGroupClassDAO(getStudyGroupClassDAO());
+            factory.setSubjectGroupMapDAO(getSubjectGroupMapDAO());
+            factory.setStudyDAO(getStudyDAO());
+            factory.setCurrentRole(currentRole);
+            factory.setCurrentUser(ub);
+            factory.setEventCRFDAO(getEventCRFDAO());
+            factory.setEventDefintionCRFDAO(getEventDefinitionCRFDAO());
+            factory.setStudyGroupDAO(getStudyGroupDAO());
+            factory.setStudyParameterValueDAO(getStudyParameterValueDAO());
+            String findSubjectsHtml = factory.createTable(request, response).render();
+            request.setAttribute("findSubjectsHtml", findSubjectsHtml);
+            forwardPage(Page.LIST_STUDY_SUBJECTS);
+        } else {
+            // HtmlFlow rendering path: supports HTMX partials (panel vs full page)
+            request.setAttribute("tableRenderingMode", "htmlflow");
+            ListStudySubjectTable table = new ListStudySubjectTable(getStudySubjectDAO(), getSubjectDAO(), getStudyEventDAO(), getStudyEventDefinitionDao(),
+                getStudyGroupClassDAO(), getSubjectGroupMapDAO(), getStudyGroupDAO(), getStudyDAO(), getEventCRFDAO(), getEventDefinitionCRFDAO(),
+                getStudyParameterValueDAO(), currentStudy, currentRole, ub, locale, session);
+            String findSubjectsHtml = table.render(request);
+            // HTMX partial handling
+            response.addHeader("Vary", "HX-Request");
+            String hxReq = request.getHeader("HX-Request");
+            if (hxReq != null) {
+                // HTMX request: only return the table HTML fragment
+                try {
+                    response.setContentType("text/html;charset=UTF-8");
+                    response.getWriter().write(findSubjectsHtml);
+                    response.getWriter().flush();
+                } catch (java.io.IOException e) {
+                    logger.error("Error writing findSubjects HTMX partial response: ", e);
+                }
+            } else {
+                // Non-HTMX request: embed into JSP and forward
+                request.setAttribute("findSubjectsHtml", findSubjectsHtml);
+                forwardPage(Page.LIST_STUDY_SUBJECTS);
+            }
+        }
 
     }
 

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
@@ -18,8 +18,12 @@ import org.xmlet.htmlapifaster.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -28,6 +32,13 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 
+/**
+ * Renders a paginated/sortable/filterable HTML table using HTMX.
+ *
+ * <p><b>Important: do not wrap this table's rendered output in your own {@code <form>}.</b>
+ * The {@link #render} method renders its own {@code <form>}. Nesting forms is invalid HTML and
+ * can lead to duplicate or conflicting query parameters being submitted.
+ */
 public class LCTable<T>  {
 
     final String tableName;     // name of the table (used for generating unique IDs and classes)
@@ -35,23 +46,72 @@ public class LCTable<T>  {
     final List<LCTableColumnDef<T>> columns;
     final Function<LCTableParams, LCTableData<T>> fetchData;
 
+    /**
+     * Explicit whitelist of "sticky" request parameters (e.g. {@code defId}) that are not related
+     * to the table's own state, but must be preserved across all table interactions (pagination, sorting, filtering).
+     * Explicitly declaring these parameters prevents forwarding arbitrary or unvetted query parameters:
+     * any parameters that are neither table-related nor in the whitelist will be dropped.
+     */
+    final List<String> stickyParamNames;
+
+    /**
+     * Optional extra controls (e.g., custom action links or dropdowns) rendered in the toolbar
+     * after the built-in controls. Added via {@link #addCustomToolbarControl} before rendering.
+     */
+    private final List<BiConsumer<Div<?>, LCTableContext<T>>> customToolbarControls = new ArrayList<>();
+
     // constants to control table behaviour
     static final boolean HIDE_PAGINATION_TOOLS_FOR_SINGLE_PAGE_TABLE = false;
 
 
     public LCTable(String tableName, List<LCTableColumnDef<T>> columns, Function<LCTableParams, LCTableData<T>> fetchData) {
+        this(tableName, columns, fetchData, Collections.emptyList());
+    }
+
+    public LCTable(String tableName, List<LCTableColumnDef<T>> columns, Function<LCTableParams, LCTableData<T>> fetchData,
+            List<String> stickyParamNames) {
         this.tableName    = tableName;
         this.panelId      = tableName + "-panel";   // Generate panel ID based on table name
         this.columns      = columns;
         this.fetchData    = fetchData;
+        this.stickyParamNames = stickyParamNames == null ? Collections.emptyList() : List.copyOf(stickyParamNames);
     }
 
     public String getTableName() {
         return tableName;
     }
+    public List<String> getStickyParamNames() { return stickyParamNames; }
 
     public List<String> getColumnNames() {
         return columns.stream().map(col -> col.columnName).collect(Collectors.toList());
+    }
+
+    /**
+     * Appends a custom control to the toolbar, rendered after built-in controls. Must be called before rendering.
+     *
+     * @param control closure that renders the control's markup into the toolbar's container {@code <div>}
+     */
+    public void addCustomToolbarControl(BiConsumer<Div<?>, LCTableContext<T>> control) {
+        customToolbarControls.add(Objects.requireNonNull(control, "control"));
+    }
+
+    /** True if this table declares at least one column with HIDDEN visibility. */
+    private boolean hasHiddenColumns() {
+        return columns.stream().anyMatch(col -> col.visibility == LCTableColumnDef.HIDDEN);
+    }
+
+    /**
+     * A column is rendered (header, filter and value cells) if it is VISIBLE, or if it is
+     * HIDDEN and the current request has opted in to show hidden columns.
+     */
+    private boolean shouldRenderColumn(LCTableColumnDef<T> col, LCTableContext<T> ctx) {
+        return col.visibility == LCTableColumnDef.VISIBLE
+            || (col.visibility == LCTableColumnDef.HIDDEN && ctx.showHiddenCols);
+    }
+
+    /** Number of columns actually rendered for the given context (used for colspan calculations). */
+    private long renderedColumnCount(LCTableContext<T> ctx) {
+        return columns.stream().filter(col -> shouldRenderColumn(col, ctx)).count();
     }
 
     // -- HTMX attribute names (use constants to avoid repeating string literals)
@@ -65,7 +125,9 @@ public class LCTable<T>  {
     // -- Generic typed table renderer -----------------------------------------
 
     private void renderColumnNames(Tr<?> tr, LCTableContext<T> ctx) {
-        columns.forEach(col -> renderColumnName(tr, col, ctx));
+        columns.forEach(col -> {
+            if (shouldRenderColumn(col, ctx)) renderColumnName(tr, col, ctx);
+        });
     }
 
     /**
@@ -84,7 +146,7 @@ public class LCTable<T>  {
             final String href = urlForSort(ctx.entityPath, ctx, col.columnName, nextSortDir);
             // Render the header cell with a link that triggers sorting via HTMX
             tr.th().attrStyle(widthStyle)
-                .a().attrClass("sort-header-link")
+                .a().attrId(tableName + "-sortable-header-" + col.columnName).attrClass("sort-header-link")
                 .attrHref(href).of(hxGetAttrs(href, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
                 .of(a -> {
                     a.span().attrClass("sort-header-text").text(col.columnDisplayName).__();
@@ -98,19 +160,38 @@ public class LCTable<T>  {
     }
 
     private void renderToolbar(Tr<?> tr, LCTableContext<T> ctx) {
-        tr.td().attrClass("toolbar").attrColspan(columns.size())
-            .div().attrStyle("display:flex;justify-content:space-between;align-items:center")
+        tr.td().attrClass("toolbar").attrColspan((int) renderedColumnCount(ctx))
+            .div().attrClass("toolbar-container")
             .of(container -> {
                 // Left: page navigation
                 container.nav().of(nav -> buildPageNavigation(nav, ctx)).__();
-                // Right: page-size selector
-                container.div().of(div -> buildMaxRowsSelector(div, ctx)).__();
+                // Separator (CSS-based vertical line)
+                container.div().attrClass("toolbar-separator").__();
+                // Immediately after navigation: dropdown-list
+                container.div().attrClass("dropdown-list").of(div -> buildSelectMaxRowsSelect(div, ctx)).__();
+                // If the table has hidden columns, show a toggle button to reveal/hide them
+                if (hasHiddenColumns()) {
+                    container.div().attrClass("toolbar-separator").__();
+                    final String toggleHref = urlForShowHiddenColsToggle(ctx);
+                    container.a().attrClass("text-btn")
+                        .attrHref(toggleHref)
+                        .of(hxGetAttrs(toggleHref, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
+                        .text(ctx.showHiddenCols ? "Hide" : "Show More")
+                        .__();
+                }
+                // Custom, non-tabular controls (see addCustomToolbarControl), in the order they were added --
+                // each preceded by the same separator used between the built-in controls above.
+                customToolbarControls.forEach(control -> {
+                    container.div().attrClass("toolbar-separator").__();
+                    control.accept(container, ctx);
+                });
             }).__();
     }
 
     private void renderFilters(Tr<?> tr, LCTableContext<T> ctx) {
-        // Render a filter input for each column
+        // Render a filter input for each rendered column
         columns.forEach(col -> {
+            if (!shouldRenderColumn(col, ctx)) return;
             if (col.isFilterable()) {
                 col.filterDef.renderFilter(tr, ctx, col, this);
             } else {
@@ -125,22 +206,24 @@ public class LCTable<T>  {
         thead.tr().attrClass("filter").of(tr -> renderFilters(tr, ctx)).__();
     }
 
-    private void renderTableBody(Tbody<?> tbody, List<T> data) {
+    private void renderTableBody(Tbody<?> tbody, LCTableContext<T> ctx) {
+        List<T> data = ctx.data.pageItems;
         tbody.attrClass("tbody");
         IntStream.range(0, data.size()).forEach(i -> {
             T item = data.get(i);
             String rowClass = ((i+1) % 2 == 0) ? "even" : "odd";    // use (i+1) to start from 1 for class assignment
             Tr<?> tr = tbody.tr().attrClass(rowClass);
-            columns.forEach(col -> col.cellRenderer.accept(tr, item));
+            columns.forEach(col -> {
+                if (shouldRenderColumn(col, ctx)) col.cellRenderer.accept(tr, item);
+            });
             tr.__();
         });
     }
 
     /**
-     * Generic typed table renderer. Each column declares its header label and
-     * a cell-renderer closure that writes directly into the HtmlFlow row element.
+     * Method that performs the actual generation of the HTML for the table.
      *
-     * @param ctx the table context containing all pagination/sorting state and the data for the current page
+     * @param ctx "context" containing all state (pagination/sorting/filtering) and data for the table
      * @return rendered HTML string
      */
     private String renderTableHtml(LCTableContext<T> ctx) {
@@ -149,17 +232,33 @@ public class LCTable<T>  {
             .div().attrId(panelId).attrClass("lctable")
             .addAttr("hx-ext", "morph")         // use 'idiomorph' extension for morphing the table content instead of replacing it
             .form().attrId(panelId + "-form")
+            // Render sticky parameters first, keeping them at the start of URLs and DOM (form) serialization order.
+            // Omitted when absent/empty.
+            .of(form -> ctx.stickyParams.forEach((name, value) -> {
+                if (value != null && !value.isEmpty()) {
+                    form.input().attrType(EnumTypeInputType.HIDDEN).attrName(name).attrValue(value).__();
+                }
+            }))
             // Hidden inputs for filter submission. Page is reset to 1 when filtering (like search box).
             // Pagination buttons use their own URLs with all parameters, so this page value
             // doesn't affect them.
             .input().attrType(EnumTypeInputType.HIDDEN).attrName(PARAM_PAGE).attrValue("1").__()
-            .input().attrType(EnumTypeInputType.HIDDEN).attrName(PARAM_MAX_ROWS).attrValue(String.valueOf(ctx.maxRows)).__()
-            .input().attrType(EnumTypeInputType.HIDDEN).attrName(PARAM_SORT_PROP).attrValue(ctx.sortProp).__()
-            .input().attrType(EnumTypeInputType.HIDDEN).attrName(PARAM_SORT_DIR).attrValue(ctx.sortDir).__()
-
+            // Hidden inputs for state submission.
+            // Note: `maxRows` is intentionally omitted here to make the `<select>` the single source of truth
+            // and avoid duplicate submissions. `sortProp`/`sortDir` and `showHiddenCols` are only rendered
+            // if they have non-default values to keep HTMX-generated query strings clean.
+            .of(form -> {
+                if (!ctx.sortProp.isEmpty()) {
+                    form.input().attrType(EnumTypeInputType.HIDDEN).attrName(PARAM_SORT_PROP).attrValue(ctx.sortProp).__();
+                    form.input().attrType(EnumTypeInputType.HIDDEN).attrName(PARAM_SORT_DIR).attrValue(ctx.sortDir).__();
+                }
+                if (ctx.showHiddenCols) {
+                    form.input().attrType(EnumTypeInputType.HIDDEN).attrName(PARAM_SHOW_HIDDEN_COLS).attrValue("true").__();
+                }
+            })
             .table().attrId(panelId + "-table").attrClass("table").attrStyle("border-collapse:collapse")
             .thead().attrId(panelId + "-thead").of(thead -> renderTableHeader(thead, ctx)).__() // thead
-            .tbody().attrId(panelId + "-tbody").attrClass("tbody").of(tbody -> renderTableBody(tbody, ctx.data.pageItems)).__() // tbody
+            .tbody().attrId(panelId + "-tbody").attrClass("tbody").of(tbody -> renderTableBody(tbody, ctx)).__() // tbody
             .tfoot().attrId(panelId + "-tfoot").of(tfoot -> renderTableFooter(tfoot, ctx)).__()
             .__() // table
             .__() // form
@@ -171,7 +270,9 @@ public class LCTable<T>  {
      * Main entry point for rendering the table.
      * Fetches the data for the current page using the provided fetchData function and renders the HTML table.
      *
+     * @param entityPath the path to the entity for which the table is being rendered
      * @param params the parameters for fetching data (page number, page size, sorting, filters, etc.)
+     * @param resourcePath the path to the resources needed for rendering the table
      * @return the rendered HTML string for the table
      */
     public String render(String entityPath, LCTableParams params, String resourcePath) {
@@ -186,7 +287,7 @@ public class LCTable<T>  {
         long    to       = (long) ctx.page * ctx.maxRows + ctx.data.pageItems.size();
 
         Tfoot<?> footer = tfoot.attrClass("statusBar");
-        Td<?> td = footer.tr().td().attrColspan(columns.size());
+        Td<?> td = footer.tr().td().attrColspan((int) renderedColumnCount(ctx));
         final int count = ctx.data.totalCountWithFilter;
         td.text(count == 0 ? "No results." : format("Results %d-%d of %d.", from, to, count)).__();
         footer.__(); // div.table-footer
@@ -204,45 +305,47 @@ public class LCTable<T>  {
         nav.attrClass("toolbar");
 
         // « first
-        pageBtn(nav, "«", url(ctx.entityPath, 0, size, sort, dir, ctx.filters), panelId, page == 0);
+        pageBtn(nav, "«", url(ctx.entityPath, 0, size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page == 0, tableName + "-nav-btn-first-page");
         // ‹ previous
-        pageBtn(nav, "‹", url(ctx.entityPath, max(0, page - 1), size, sort, dir, ctx.filters), panelId, page == 0);
+        pageBtn(nav, "‹", url(ctx.entityPath, max(0, page - 1), size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page == 0, tableName + "-nav-btn-prev-page");
         // numbered slots / ellipsis
         for (LCTablePageSlot slot : ctx.slots) {
             if (slot.ellipsis()) {
                 nav.span().attrClass("page-ellipsis").text("…").__();
             } else {
-                String slotHref = url(ctx.entityPath, slot.page(), size, sort, dir, ctx.filters);
-                nav.a().attrClass("page-btn" + (slot.current() ? " current" : ""))
+                String slotHref = url(ctx.entityPath, slot.page(), size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams);
+                nav.a().attrId(tableName + "-nav-btn-page-" + (slot.page() + 1))
+                    .attrClass("text-btn" + (slot.current() ? " current" : ""))
                     .attrHref(slotHref).of(hxGetAttrs(slotHref, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
                     .text(String.valueOf(slot.page() + 1))
                     .__(); // a
             }
         }
         // › next
-        pageBtn(nav, "›", url(ctx.entityPath, min(total - 1, page + 1), size, sort, dir, ctx.filters), panelId, page >= total - 1);
+        pageBtn(nav, "›", url(ctx.entityPath, min(total - 1, page + 1), size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page >= total - 1, tableName + "-nav-btn-next-page");
         // » last
-        pageBtn(nav, "»", url(ctx.entityPath, total - 1, size, sort, dir, ctx.filters), panelId, page >= total - 1);
+        pageBtn(nav, "»", url(ctx.entityPath, total - 1, size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page >= total - 1, tableName + "-nav-btn-last-page");
 
         nav.__(); // nav.pagination
     }
 
     /** Writes a single pagination button into the given {@code nav} element. */
-    private void pageBtn(Nav<?> nav, String text, String href, String panelId, boolean disabled) {
-        nav.a().attrClass("page-btn" + (disabled ? " disabled" : ""))
+    private void pageBtn(Nav<?> nav, String text, String href, String panelId, boolean disabled, String id) {
+        nav.a().attrId(id).attrClass("text-btn" + (disabled ? " disabled" : ""))
             .attrHref(href).of(hxGetAttrs(href, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
             .text(text)
             .__(); // a
     }
 
-    /** Builds the page-size selector (maxRows) and appends it into the provided div. */
-    private void buildMaxRowsSelector(Div<?> div, LCTableContext<T> ctx) {
+    /** Builds the {@code select} element for 'maxRows' and appends it into the provided div. */
+    private void buildSelectMaxRowsSelect(Div<?> div, LCTableContext<T> ctx) {
         if (HIDE_PAGINATION_TOOLS_FOR_SINGLE_PAGE_TABLE && ctx.totalPages <= 1) return;
-        div.attrClass("page-size");
-        div.label().text("Rows: ").__();
+        div.label().text("").__();    // replace "" by "Rows: " if you want to make explicit what the select element is for
         div.select()
+            .attrId(tableName + "-select-max-rows")
             .attrName(PARAM_MAX_ROWS)
-            .of(hxGetAttrs(ctx.entityPath, "#" + panelId + " input, #" + panelId + " select", "#" + panelId, "change"))
+            // Uses "closest form" to submit maxRows along with all other table-state fields.
+            .of(hxGetAttrs(ctx.entityPath, "closest form", "#" + panelId, "change"))
             .of(select -> {
                 for (int s : new int[]{15, 25, 50}) {
                     if (s == ctx.maxRows) {
@@ -259,37 +362,53 @@ public class LCTable<T>  {
      * (effectively removing the sort). Otherwise, include both sortProp and sortDir.
      */
     private String urlForSort(String path, LCTableContext<T> ctx, String columnName, String sortDir) {
-        UriComponentsBuilder builder = UriComponentsBuilder.fromPath(path)
-            .queryParam(PARAM_PAGE, 1)  // reset to page 1 when sorting changes
-            .queryParam(PARAM_MAX_ROWS, ctx.maxRows);
-        if (sortDir != null) {
-            builder.queryParam(PARAM_SORT_PROP, columnName);
+        // The page is reset to 1 (index 0) whenever sorting changes. No need to null out columnName
+        // ourselves when sortDir is null: url() already treats sortProp/sortDir as an atomic pair
+        // and omits both unless both are present.
+        return url(path, 0, ctx.maxRows, columnName, sortDir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams);
+    }
+
+    /**
+     * Build the URL for the "Show More" / "Hide" toggle button that reveals or conceals HIDDEN columns.
+     * Preserves all current table-state parameters (page, maxRows, sort, filters) and simply flips
+     * the {@link LCTableContext#showHiddenCols} flag (omitted from the URL when turned off).
+     */
+    private String urlForShowHiddenColsToggle(LCTableContext<T> ctx) {
+        return url(ctx.entityPath, ctx.page, ctx.maxRows, ctx.sortProp, ctx.sortDir, ctx.filters, !ctx.showHiddenCols, ctx.stickyParams);
+    }
+
+    /**
+     * Builds a complete URL with all table-state parameters.
+     * Omits null/empty parameters to keep URLs clean. Sticky parameters are listed first.
+     * {@code page} is converted from 0-based (internal representation) to 1-based (URL representation).
+     */
+    private String url(String path, int page, int maxRows, String sortProp, String sortDir, Map<String, String> filters, boolean showHiddenCols,
+            Map<String, String> stickyParams) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromPath(path);
+        if (stickyParams != null) {
+            stickyParams.forEach((key, val) -> addParamIfPresent(builder, key, val));
+        }
+        builder.queryParam(PARAM_PAGE, page + 1)
+            .queryParam(PARAM_MAX_ROWS, maxRows);
+        if (sortProp != null && !sortProp.isEmpty() && sortDir != null && !sortDir.isEmpty()) {
+            builder.queryParam(PARAM_SORT_PROP, sortProp);
             builder.queryParam(PARAM_SORT_DIR, sortDir);
         }
-        if (ctx.filters != null) {
-            ctx.filters.forEach((key, val) -> {
-                if (val != null && !val.isEmpty()) builder.queryParam(PARAM_FILTER_PREFIX + key, val);
-            });
+        if (filters != null) {
+            filters.forEach((key, val) -> addParamIfPresent(builder, PARAM_FILTER_PREFIX + key, val));
+        }
+        if (showHiddenCols) {
+            builder.queryParam(PARAM_SHOW_HIDDEN_COLS, "true");
         }
         return builder.encode().toUriString();
     }
 
-    /**
-     * Build an application URL with all table-state parameters.
-     * Filter parameters are URL-encoded and appended as <PARAM_FILTER_PREFIX>.<columnName>=value.
-     */
-    private String url(String path, int page, int maxRows, String sortProp, String sortDir, Map<String, String> filters) {
-        UriComponentsBuilder builder = UriComponentsBuilder.fromPath(path)
-            .queryParam(PARAM_PAGE, page + 1)
-            .queryParam(PARAM_MAX_ROWS, maxRows)
-            .queryParam(PARAM_SORT_PROP, sortProp == null ? "" : sortProp)
-            .queryParam(PARAM_SORT_DIR, sortDir == null ? "asc" : sortDir);
-        if (filters != null) {
-            filters.forEach((key, val) -> {
-                if (val != null && !val.isEmpty()) builder.queryParam(PARAM_FILTER_PREFIX + key, val);
-            });
+
+    /** Adds {@code key=val} to {@code builder} unless {@code val} is null or empty, to avoid emitting ugly/redundant empty query parameters. */
+    private static void addParamIfPresent(UriComponentsBuilder builder, String key, String val) {
+        if (val != null && !val.isEmpty()) {
+            builder.queryParam(key, val);
         }
-        return builder.encode().toUriString();
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
@@ -20,13 +20,20 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 /**
- * Describes one column of a typed table: an internal name (used in URLs/filters),
- * a display name (rendered in the header) and a closure that writes the cell
- * content for a given row bean into the HtmlFlow row element.
+ * Describes a table column: internal name, header display name, a cell-rendering closure and various other properties (width, visibility, sortability, filter definition).
  *
  * @param <T> record (row) type
  */
 public class LCTableColumnDef<T> {
+
+    public enum Visibility {
+        VISIBLE,
+        HIDDEN;
+        public boolean isVisible() { return this == VISIBLE; }
+        public boolean isHidden() { return this == HIDDEN; }
+    }
+    public static final Visibility VISIBLE = Visibility.VISIBLE;
+    public static final Visibility HIDDEN = Visibility.HIDDEN;
 
     public enum Sortability {
         SORTABLE,
@@ -48,6 +55,9 @@ public class LCTableColumnDef<T> {
     /** Width of the column (in rem) */
     public final double columnWidth;
 
+    /** Visibility of the column (default: visible) */
+    public final Visibility visibility;
+
     /** Flag to indicate whether column data is sortable or not */
     public final Sortability sortability;
 
@@ -58,29 +68,31 @@ public class LCTableColumnDef<T> {
     public final BiConsumer<Tr<?>, T> cellRenderer;
 
     // General constructor
-    public LCTableColumnDef(String columnName, String columnDisplayName, double columnWidth, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
+    public LCTableColumnDef(String columnName, String columnDisplayName, double columnWidth, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
         this.columnName = columnName;
         this.columnDisplayName = columnDisplayName;
         this.columnWidth = columnWidth;
+        this.visibility = visibility;
         this.sortability = sortability;
         this.filterDef = filterDef;
         this.cellRenderer = cellRenderer;
     }
 
+    public boolean isVisible() { return this.visibility == Visibility.VISIBLE; }
 
-    public boolean isSortable() { return this.sortability.isSortable();  }
+    public boolean isSortable() {
+        return this.sortability.isSortable();
+    }
     public boolean isFilterable() { return this.filterDef != null; }
 
     // Basic factory method
-    public static <T> LCTableColumnDef<T> columnDef(String columnName, String displayName, double columnWidth, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, columnWidth, sortability, filterDef, cellRenderer);
+    public static <T> LCTableColumnDef<T> columnDef(String columnName, String displayName, double columnWidth, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
+        return new LCTableColumnDef<>(columnName, displayName, columnWidth, visibility, sortability, filterDef, cellRenderer);
     }
 
     // --- 1. Null-safe cell generator ('Optional'-based) ---
 
-    /**
-     * Core helper: Opens a Td, evaluates the Optional pipeline, renders the value or a fallback, and safely closes the Td.
-     */
+    /** Evaluates the Optional pipeline, safely rendering the value or a fallback '—'. */
     private static <T, V> BiConsumer<Tr<?>, T> nullSafeCell(
         Function<Optional<T>, Optional<V>> pipeline,
         BiConsumer<Td<?>, V> finish
@@ -108,47 +120,71 @@ public class LCTableColumnDef<T> {
     // --- 3. Column factory methods for text columns ---
 
     public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Function<T, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(renderer));
     }
 
+    public static <T> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, Function<T, String> renderer) {
+        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(renderer));
+
+    }
     public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, filterDef, nullSafeColText(renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, filterDef, nullSafeColText(renderer));
+    }
+
+    public static <T> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
+        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, filterDef, nullSafeColText(renderer));
     }
 
     public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Function<T, F> extractor, Function<F, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(extractor, renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(extractor, renderer));
+    }
+
+    public static <T, F> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, Function<T, F> extractor, Function<F, String> renderer) {
+        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(extractor, renderer));
     }
 
     public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, filterDef, nullSafeColText(extractor, renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, filterDef, nullSafeColText(extractor, renderer));
+    }
+
+    public static <T, F> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
+        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, filterDef, nullSafeColText(extractor, renderer));
     }
 
     // --- 4. Column factory methods for enum-like types (similar to textCol, but with list of allowed value and 'select' filter ---
 
     public static <T, V> LCTableColumnDef<T> enumCol(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
+    }
+
+    public static <T, V> LCTableColumnDef<T> enumColHidden(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
+        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
     }
 
     public static <T, V> LCTableColumnDef<T> enumColNotSortable(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(colRenderer));
     }
 
     public static <T, V> LCTableColumnDef<T> enumCol(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return new LCTableColumnDef<>(columnName, displayName, width, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
+    }
+
+    public static <T, V> LCTableColumnDef<T> enumColHidden(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
+        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
     }
 
     public static <T, V> LCTableColumnDef<T> enumColNotSortable(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return new LCTableColumnDef<>(columnName, displayName, width, NOT_SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(extractor, renderer));
     }
 
     // --- 5. Column factory methods for custom 'td' rendering ---
 
     public static <T> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Td<?>, T> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, sortability, filterDef, nullSafeCell(Function.identity(), renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, sortability, filterDef, nullSafeCell(Function.identity(), renderer));
     }
 
     public static <T, F> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> extractor, BiConsumer<Td<?>, F> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, sortability, filterDef, nullSafeCell(row -> row.map(extractor), renderer));
+        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, sortability, filterDef, nullSafeCell(row -> row.map(extractor), renderer));
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableContext.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableContext.java
@@ -18,14 +18,7 @@ import java.util.stream.Collectors;
 import java.util.Arrays;
 import java.util.Collections;
 
-/**
- * Immutable view-context passed to every lctable entity builder.
- *
- * <p>Holds all pagination / filter state that the shared fragments
- * (controls-bar, sort-th, table-footer) and the entity-specific builders need.
- *
- * @since 9
- */
+/** Immutable view-context holding pagination/sorting/filtering state and current page data. */
 public final class LCTableContext<T> {
 
     // parameters (from the request URL)
@@ -34,6 +27,10 @@ public final class LCTableContext<T> {
     public final String sortProp;
     public final String sortDir;
     public final Map<String, String> filters;
+    public final boolean showHiddenCols;
+
+    /** Current values of this table's "sticky" parameters -- see {@link LCTable#stickyParamNames}. */
+    public final Map<String, String> stickyParams;
 
     // paths (derived from the request URL)
     public final String entityPath;
@@ -55,6 +52,8 @@ public final class LCTableContext<T> {
         this.sortProp = params.sortProp;
         this.sortDir = params.sortDir;
         this.filters = params.filters;
+        this.showHiddenCols = params.showHiddenCols;
+        this.stickyParams = params.stickyParams;
         this.data = fetchData.apply(params);
 
         this.entityPath = entityPath;

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableFilterDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableFilterDef.java
@@ -41,7 +41,7 @@ public abstract class LCTableFilterDef {
 
     /*----------------------------------------------------------------------------------------------------------------*/
     /**
-     * Text filter specialization: renders an <input type="text"> with optional pattern/title
+     * Text filter specialization: renders an {@code <input type="text">} with optional pattern/title
      */
     public static final class Text extends LCTableFilterDef {
         public final String pattern;   // Regex pattern for HTML5 validation
@@ -62,10 +62,8 @@ public abstract class LCTableFilterDef {
             final String filterName = LCTableParams.PARAM_FILTER_PREFIX + col.columnName;
             final String filterValue = ctx.filters.getOrDefault(col.columnName, "");
 
-            // Every change in the input resets the debounce timer (no trigger-filter here).
-            // Validity is instead checked right before the request actually fires, via hx-on below.
-            // Filtering the triggering event itself would let a stale, already-scheduled timer fire later
-            // with a value that in the meantime has changed, leading to a request with an invalid value.
+            // Every change in the input triggers a request with a delay (resetting the debounce timer).
+            // Validity is checked via 'hx-on' right before sending out the request, to prevent submitting invalid values.
             final String trigger = "input changed delay:400ms";
 
             tr.td().div().attrClass("filter-wrapper").of(div -> {
@@ -75,7 +73,7 @@ public abstract class LCTableFilterDef {
                     .attrValue(filterValue)
                     .attrClass("filter-input")
                     .attrSize(1L)
-                    .attrId(table.panelId + "-filter-" + col.columnName);
+                    .attrId(table.tableName + "-text-filter-" + col.columnName);
 
                 // If a pattern is provided, add HTML5 validation and HTMX event filter
                 if (this.pattern != null) {
@@ -96,7 +94,7 @@ public abstract class LCTableFilterDef {
 
     /*----------------------------------------------------------------------------------------------------------------*/
     /**
-     * Select filter specialization: renders a <select> with provided values
+     * Select filter specialization: renders a {@code <select>} with provided values
      */
     public static final class Select<F> extends LCTableFilterDef {
         public final List<F> values;
@@ -148,18 +146,16 @@ public abstract class LCTableFilterDef {
             final String filterName = LCTableParams.PARAM_FILTER_PREFIX + col.columnName;
             final String rawSelected = ctx.filters.getOrDefault(col.columnName, "");
 
-            // UI Safety Check: Verify if the URL parameter actually matches a real option
+            // UI Safety Check: Verify the URL parameter matches a valid option; otherwise, default to empty.
             final boolean isValidOption = rawSelected.isEmpty() || this.values.stream()
                 .map(this::urlParam)
                 .anyMatch(val -> val.equals(rawSelected));
-
-            // If it's invalid (e.g., "broken"), treat it as empty ("All") so the UI snaps back to a valid state
             final String currentSelected = isValidOption ? rawSelected : "";
 
             tr.td().div().attrClass("filter-wrapper").of(div -> {
                 var select = div.select()
                     .attrName(filterName)
-                    .attrId(table.panelId + "-filter-" + col.columnName)
+                    .attrId(table.tableName + "-select-filter-" + col.columnName)
                     .attrClass("filter-select")
                     .attrStyle("width:1px;flex:1")
                     .of(hxGetAttrs(ctx.entityPath, "closest form", "#" + table.panelId, "change"));
@@ -178,27 +174,34 @@ public abstract class LCTableFilterDef {
 
     /*----------------------------------------------------------------------------------------------------------------*/
     /**
-     * Clear filter specialization: renders a button that clears all filters when clicked.
-     *
-     * <p>Uses a precise {@code hx-include} CSS selector that names only the non-filter parameters
-     * (page, maxRows, sortProp, sortDir) by their exact {@code name} attribute. Filter inputs are
-     * never selected, so they are never included in the HTMX request — no JavaScript required.
+     * Clear filter specialization: renders a button that clears all filters.
+     * Uses a precise CSS selector to include only non-filter parameters in the HTMX request.
      */
     public static final class ClearFilter extends LCTableFilterDef {
-        // CSS selector that picks up only the pagination/sort form fields, excluding all filter inputs.
+        // CSS selector targeting pagination/sort/hidden columns fields, excluding filter inputs.
         private static final String NON_FILTER_PARAMS_SELECTOR =
             "[name=" + LCTableParams.PARAM_PAGE + "]" +
                 ",[name=" + LCTableParams.PARAM_MAX_ROWS + "]" +
                 ",[name=" + LCTableParams.PARAM_SORT_PROP + "]" +
-                ",[name=" + LCTableParams.PARAM_SORT_DIR + "]";
+                ",[name=" + LCTableParams.PARAM_SORT_DIR + "]" +
+                ",[name=" + LCTableParams.PARAM_SHOW_HIDDEN_COLS + "]";
 
         @Override
         public <T, E extends Element<?, ?>> void renderFilter(Tr<E> tr, LCTableContext<T> ctx, LCTableColumnDef<T> col, LCTable<T> table) {
-            tr.td().a().attrClass("page-btn")
-                .of(hxGetAttrs(ctx.entityPath, NON_FILTER_PARAMS_SELECTOR, "#" + table.panelId, "click"))
+            StringBuilder selector = new StringBuilder(NON_FILTER_PARAMS_SELECTOR);
+            // Append the per-table "sticky" parameter names to the selector, to preserve them when clearing filters.
+            for (String stickyParamName : table.getStickyParamNames()) {
+                selector.append(",[name=").append(stickyParamName).append(']');
+            }
+            tr.td().a()
+                .attrId(table.tableName + "-clear-filter-" + col.columnName)
+                .attrClass("text-btn")
+                .of(hxGetAttrs(ctx.entityPath, selector.toString(), "#" + table.panelId, "click"))
                 .text("Clear Filter")
                 .__().__();
         }
     }
 
 }
+
+

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTablePageSlot.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTablePageSlot.java
@@ -10,11 +10,7 @@
  */
 package org.akaza.openclinica.lctable;
 
-/**
- * One slot in the pagination window used by the lctable renderer.
- *
- * <p>Immutable, but implemented as a plain class (not a record) for Java 11 compatibility.
- */
+/** A single pagination slot (page number or ellipsis). */
 public final class LCTablePageSlot {
 
 	private final int page;

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableParams.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableParams.java
@@ -11,6 +11,7 @@
 package org.akaza.openclinica.lctable;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,7 +21,10 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
 
-
+/**
+ * An {@code LCTableParams} object is an immutable object holding the URL parameters of a request
+ * to an {@link LCTable} (pagination, sorting, filtering, etc.).
+ */
 public final class LCTableParams {
 
     // -- URL parameter names --------------------------------------------------
@@ -28,6 +32,7 @@ public final class LCTableParams {
     public static final String PARAM_MAX_ROWS = "maxRows";
     public static final String PARAM_SORT_PROP = "sortProp";
     public static final String PARAM_SORT_DIR = "sortDir";
+    public static final String PARAM_SHOW_HIDDEN_COLS = "showHiddenCols";
     public static final String PARAM_FILTER_PREFIX = "q.";
 
     // --- URL parameters -------------------------------------------------------
@@ -36,27 +41,35 @@ public final class LCTableParams {
     public final String sortProp;
     public final String sortDir;
     public final Map<String, String> filters;
+    public final boolean showHiddenCols;
+
+    /** Explicitly whitelisted "sticky" parameters from incoming request (see {@link LCTable#stickyParamNames}). */
+    public final Map<String, String> stickyParams;
 
     // --- it needs to be package-private for unit-testing, should not be called by regular users of the library ---
     LCTableParams(int page, int maxRows, String sortProp, String sortDir, Map<String, String> filters) {
+        this(page, maxRows, sortProp, sortDir, filters, false, Collections.emptyMap());
+    }
+
+    // --- it needs to be package-private for unit-testing, should not be called by regular users of the library ---
+    LCTableParams(int page, int maxRows, String sortProp, String sortDir, Map<String, String> filters, boolean showHiddenCols) {
+        this(page, maxRows, sortProp, sortDir, filters, showHiddenCols, Collections.emptyMap());
+    }
+
+    // --- it needs to be package-private for unit-testing, should not be called by regular users of the library ---
+    LCTableParams(int page, int maxRows, String sortProp, String sortDir, Map<String, String> filters, boolean showHiddenCols,
+            Map<String, String> stickyParams) {
         this.page = page;
         this.maxRows = maxRows;
         this.sortProp = sortProp;
         this.sortDir = sortDir;
         this.filters = filters;
+        this.showHiddenCols = showHiddenCols;
+        this.stickyParams = stickyParams == null ? Collections.emptyMap() : stickyParams;
     }
 
     /**
-     * Construct a LcTableParams object by reading request parameters from a Spring MultiValueMap
-     * (as provided by a controller with {@code @RequestParam MultiValueMap<String,String> allParams}).
-     * The helper methods intParam, strParam and readFilters are used to parse and normalise the parameter values.
-     *
-     * <p><b>Important:</b> the values in {@code params} are expected to be already URL-decoded, as
-     * they normally are when the map is populated by Spring MVC from an incoming request
-     * (e.g. via {@code @RequestParam MultiValueMap<String, String>}). Neither this constructor nor
-     * {@link #readFilters(MultiValueMap, List)} performs any decoding of parameter values.
-     * Decoding an already-decoded value again would corrupt any value containing a literal {@code %}
-     * would throw an {@code IllegalArgumentException} on a second decode attempt.
+     * Constructs an {@link LCTableParams} object from a Spring {@link org.springframework.util.MultiValueMap}. Expects values to already be URL-decoded.
      */
     public LCTableParams(MultiValueMap<String, String> params, LCTable<?> table) {
         this.page = Math.max(intParam(params, PARAM_PAGE, 1) - 1, 0);
@@ -65,28 +78,20 @@ public final class LCTableParams {
         this.sortProp = strParam(params, PARAM_SORT_PROP, "");
         this.sortDir  = strParam(params, PARAM_SORT_DIR, "asc");
         this.filters  = readFilters(params, table.getColumnNames());
+        this.showHiddenCols = boolParam(params, PARAM_SHOW_HIDDEN_COLS);
+        this.stickyParams = readStickyParams(params, table.getStickyParamNames());
     }
 
     /**
-     * Construct a LcTableParams object by reading request parameters from a legacy servlet query string
-     * as returned by {@code HttpServletRequest.getQueryString()}
+     * Constructs an {@link LCTableParams} object <b>from a raw, URL-encoded query string</b> {@code queryString}, decoding values explicitly before mapping.<br><br>
+     * Typically, {@code queryString} is the value returned by {@link javax.servlet.http.HttpServletRequest#getQueryString()},
+     * which is <b>not</b> decoded by the servlet container.<br><br>Passing an already-decoded string to this constructor could cause
+     * a "double decoding" issue, possibly resulting in an {@code IllegalArgumentException} (e.g. for values containing a literal {@code %}).
      *
-     * <p><b>Precondition:</b> {@code queryString} must be the raw, still URL-encoded query string exactly
-     * as it appears on the wire, e.g. the value returned by {@link javax.servlet.http.HttpServletRequest#getQueryString()},
-     * which is <b>not</b> decoded by the servlet container. This constructor:<br>
-     * 1. parses the {@code queryString} with {@link UriComponentsBuilder#fromUriString(String)},
-     * which does not decode query parameter values,<br>
-     * 2. then explicitly URL-decodes all parameter values before delegating to {@link #LCTableParams(MultiValueMap, LCTable)},
-     * which in turn expects to receive already-decoded values (see its Javadoc).
-     * <p>Passing an already-decoded string here would cause the decoding step to run against decoded input, which
-     * throws an {@code IllegalArgumentException} for any value containing a literal {@code %}.
-     *
-     * @param queryString the query string from the request
-     * @param table the {@link LCTable} instance (used in {@link LCTableParams} to get the list of allowed filter keys)
+     * @param queryString the raw query string from the request
+     * @param table the {@link LCTable} instance
      */
     public LCTableParams(String queryString, LCTable<?> table) {
-        // .build().encode() would double-encode; instead decode explicitly here,
-        // at the one place that's actually receiving a raw/encoded map.
         this(decodeQueryParams(UriComponentsBuilder.fromUriString("?" + (queryString == null ? "" : queryString))
             .build().getQueryParams()), table);
     }
@@ -99,14 +104,9 @@ public final class LCTableParams {
     }
 
     /**
-     * Reads all filter request parameters starting with {@value #PARAM_FILTER_PREFIX}.
-     *
-     * <p><b>Important:</b> values are copied as-is and are <b>not</b> URL-decoded by this method.
-     * Callers must ensure {@code params} already contains decoded values — this is the case for a
-     * {@code MultiValueMap} populated by Spring MVC from an incoming request, but not for one built
-     * directly from a raw query string. Decoding here would risk double-decoding values that were
-     * already decoded upstream, which throws {@code IllegalArgumentException} for any value
-     * containing a literal {@code %} (e.g. {@code "100%"}).
+     * Extracts from {@code params} all filter parameters, i.e. those starting with {@value #PARAM_FILTER_PREFIX}.<br><br>
+     * Values are copied as-is and are <b>not</b> URL-decoded by this method.
+     * Therefore, they must already be URL-decoded by the caller.
      */
     public static Map<String, String> readFilters(MultiValueMap<String, String> params, List<String> allowedKeys) {
         Map<String, String> filters = new LinkedHashMap<>();
@@ -122,6 +122,25 @@ public final class LCTableParams {
             });
         }
         return filters;
+    }
+
+    /**
+     * Extracts from {@code params} the explicitly whitelisted "sticky" parameters (see {@link LCTable#stickyParamNames}),
+     * omitting any such parameters that are absent or blank.<br><br>
+     * Values are copied as-is and are <b>not</b> URL-decoded by this method.
+     * Therefore, they must already be URL-decoded by the caller.
+     */
+    public static Map<String, String> readStickyParams(MultiValueMap<String, String> params, List<String> stickyParamNames) {
+        Map<String, String> stickyParams = new LinkedHashMap<>();
+        if (params != null && stickyParamNames != null) {
+            for (String name : stickyParamNames) {
+                String value = params.getFirst(name);
+                if (value != null && !value.isEmpty()) {
+                    stickyParams.put(name, value);
+                }
+            }
+        }
+        return stickyParams;
     }
 
     /**
@@ -147,13 +166,24 @@ public final class LCTableParams {
         return v == null ? defaultValue : v;
     }
 
+    /**
+     * Reads a boolean request parameter, returning true if the parameter is present and
+     * equals "true" (case-insensitive), or false otherwise.
+     */
+    public static boolean boolParam(MultiValueMap<String, String> params, String name) {
+        String v = params == null ? null : params.getFirst(name);
+        return v != null && v.trim().equalsIgnoreCase("true");
+    }
+
 
     public String toString() {
         return "LcTableParams[page=" + page
             + ", maxRows=" + maxRows
             + ", sortProp=" + sortProp
             + ", sortDir=" + sortDir
-            + ", filters=" + filters + "]";
+            + ", filters=" + filters
+            + ", showHiddenCols=" + showHiddenCols
+            + ", stickyParams=" + stickyParams + "]";
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
@@ -14,7 +14,7 @@ import static org.akaza.openclinica.lctable.LCTable.*;
 
 import org.xmlet.htmlapifaster.CustomAttributeGroup;
 import org.xmlet.htmlapifaster.Element;
-import org.xmlet.htmlapifaster.Td;
+import org.xmlet.htmlapifaster.FlowContent;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -47,11 +47,11 @@ public class LCTableUtil {
             el.addAttr(HX_TARGET, hxTarget);
             el.addAttr("hx-select", hxTarget);
             if (ignoreActiveValue) {
-                // for incremental input filters and the like, where the user may continue typing
-                // while the request is in flight: do not replace value with the value from the response
+                // For incremental input filters and the like, where the user may continue typing while the request
+                // is in flight: 'ignoreActiveValue:true' prevents replacing the input with the value from the response
                 el.addAttr(HX_SWAP, "morph:{morphStyle:'outerHTML',ignoreActiveValue:true}");
             } else {
-                // other cases: replace the entire target element with the response (outerHTML)
+                // Other cases: replace the entire target element with the response (outerHTML)
                 el.addAttr(HX_SWAP, "outerHTML");
             }
             if (hxTrigger != null) el.addAttr(HX_TRIGGER, hxTrigger);
@@ -86,19 +86,38 @@ public class LCTableUtil {
 
     // --- generate HTML for various common elements ---
     /**
-     * Convenience helper to construct an icon with a link.
-     * Use like: td.of(LCTableUtil.iconLink("View", href, "images/bt_View.gif", "View"));
+     * Constructs an action link, optionally with a text label if {@code includeText} is true. If {@code includeText} is false, uses
+     * a custom {@code data-tooltip} (implemented in {@code lctable.js} and {@code lctable.css}) instead of the native {@code title} attribute
+     * (which can be flaky) to display the {@code altText}.
      *
-     * @param altTitle  title/alt text to put on the anchor (and used as title on the anchor)
-     * @param href      href for the anchor
-     * @param imgSrc    src for the inner img
-     * @param imgAlt    alt text for the inner img
+     * @param id          unique HTML element id or null if none
+     * @param altText     accessible name / tooltip text
+     * @param href        href for the anchor
+     * @param imgSrc      src (relative to "images/") for the inner img
+     * @param includeText if true, renders {@code altText} as a visible label; if false, icon-only with a tooltip
      */
-    public static <T extends Element<?, ?>> Consumer<Td<T>> linkIcon(String altTitle, String href, String imgSrc, String imgAlt) {
-        return td -> td
-            .a().attrHref(href).attrTitle(altTitle)
-            .img().attrSrc(imgSrc).attrAlt(imgAlt).__()
-            .__();  // close a()
+    public static <T extends Element<T, Z> & FlowContent<T, Z>, Z extends Element> Consumer<T> actionLink(
+            String id, String altText, SafeUrl href, String imgSrc, boolean includeText) {
+        return container -> {
+            var anchor = container.a().attrClass("action-link").attrHref(href.toUriString()).addAttr("aria-label", altText);
+            if (id != null) {
+                anchor = anchor.attrId(id);
+            }
+            if (!includeText) {
+                anchor = anchor.addAttr("data-tooltip", altText);
+            }
+            var a = anchor.img().attrSrc("images/" + imgSrc).attrAlt(altText).__();
+            if (includeText) {
+                a.text(" " + altText);
+            }
+            a.__();  // close a()
+        };
+    }
+
+    /** Icon-only variant of {@link #actionLink(String, String, SafeUrl, String, boolean)} (no visible text label). */
+    public static <T extends Element<T, Z> & FlowContent<T, Z>, Z extends Element> Consumer<T> actionLink(
+            String id, String altText, SafeUrl href, String imgSrc) {
+        return actionLink(id, altText, href, imgSrc, false);
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/SafeUrl.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/SafeUrl.java
@@ -1,0 +1,72 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+
+ * For details see: https://libreclinica.org/license
+ * copyright (C) 2026 LibreClinica
+ *
+ * Author: Giuseppe Del Castillo
+ * Development sponsored by ReliaTec GmbH
+ */
+package org.akaza.openclinica.lctable;
+
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.function.Function;
+
+public final class SafeUrl {
+    private final UriComponentsBuilder builder;
+
+    private SafeUrl(String basePath) {
+        this.builder = UriComponentsBuilder.fromUriString(basePath);
+    }
+
+    public static SafeUrl url(String basePath) {
+        return new SafeUrl(basePath);
+    }
+
+    // 1. Accept strings (the builder will handle the URL escaping)
+    public SafeUrl param(String name, String value) {
+        if (value != null && !value.isEmpty()) {
+            this.builder.queryParam(name, value);
+        }
+        return this;
+    }
+
+    // 2. Accept specific primitives that we know how to handle safely (the builder will handle the URL escaping)
+    public SafeUrl param(String name, int value) {
+        this.builder.queryParam(name, value);
+        return this;
+    }
+
+    public SafeUrl param(String name, long value) {
+        this.builder.queryParam(name, value);
+        return this;
+    }
+
+    public SafeUrl param(String name, boolean value) {
+        this.builder.queryParam(name, value);
+        return this;
+    }
+
+    // 3. Accept Enums safely by using their name or a custom enum-to-string conversion function (the builder will handle the URL escaping)
+    public SafeUrl param(String name, Enum<?> value) {
+        if (value != null) {
+            this.builder.queryParam(name, value.name());
+        }
+        return this;
+    }
+
+    public SafeUrl param(String name, Enum<?> value, Function<Enum<?>, String> enumToString) {
+        if (value != null) {
+            this.builder.queryParam(name, enumToString.apply(value));
+        }
+        return this;
+    }
+
+    // Other types (e.g., Date, arrays) are not supported and must be converted to String or primitives by the caller.
+
+    public String toUriString() {
+        return this.builder.build().encode().toUriString();
+    }
+}

--- a/web/src/main/webapp/WEB-INF/jsp/admin/auditUserActivity.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/auditUserActivity.jsp
@@ -80,11 +80,28 @@
 <jsp:useBean id="now" class="java.util.Date" />
 <P><I><fmt:message key="server_time_info" bundle="${resword}"/> <fmt:formatDate value="${now}" pattern="yyyy-MM-dd HH:mm"/>.</I></P>
 <div id="auditUserLoginDiv">
-    <form  action="${pageContext.request.contextPath}/AuditUserActivity">
-        <input type="hidden" name="module" value="admin">
-        <input type="hidden" name="crfId" value="${crf.id}">
-        ${auditUserLoginHtml}
-    </form>
+    <%-- IMPORTANT: the LCTable (HtmlFlow) rendering path renders its own <form> around the whole
+         table (see LCTable.renderTableHtml()) -- it must NOT also be wrapped in a <form> here, or
+         the browser will treat the two nested <form>s as a single merged form (nested <form>s are
+         invalid HTML; the inner start tag is simply dropped by the parser), causing any hidden
+         input declared in *this* JSP (e.g. hardcoded "module"/"crfId") to collide with LCTable's
+         own same-named hidden inputs (e.g. a sticky parameter of the same name) once both are
+         serialized together by HTMX's "closest form" -- see LCTable's class-level javadoc for
+         details, and see the analogous fix in managestudy/findSubjects.jsp.
+         Only the legacy JMesa rendering path (native form-based pagination/sort/filter resubmission,
+         via createHiddenInputFieldsForLimitAndSubmit()) actually needs a surrounding <form>. --%>
+    <c:choose>
+        <c:when test="${tableRenderingMode == 'jmesa'}">
+            <form  action="${pageContext.request.contextPath}/AuditUserActivity">
+                <input type="hidden" name="module" value="admin">
+                <input type="hidden" name="crfId" value="${crf.id}">
+                ${auditUserLoginHtml}
+            </form>
+        </c:when>
+        <c:otherwise>
+            ${auditUserLoginHtml}
+        </c:otherwise>
+    </c:choose>
 </div>
 
 
@@ -92,6 +109,6 @@
 <input type="button" onclick="confirmExit('ListUserAccounts');"  name="exit" value="<fmt:message key="exit" bundle="${resword}"/>   " class="button_medium"/>
 
 <!-- Include everything that is needed for proper use of HTMX with LCTable -->
-<jsp:include page="../include/useHtmx.jsp"/>
+<jsp:include page="../include/useLCTable.jsp"/>
 
 <jsp:include page="../include/footer.jsp"/>

--- a/web/src/main/webapp/WEB-INF/jsp/include/useLCTable.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/include/useLCTable.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 
-<!-- This JSP fragment is used to include in a JSP page everything that is needed for HTMX to work properly
-      (especially for the implementation of / in connection with the LCTable library)
+<!-- This JSP fragment is used to include in a JSP page everything that is needed for LCTable to work properly
+      (especially, but not only, in connection with HTMX)
 -->
 
 <!-- Load HTMX, which is provided by the webjar declared in web/pom.xml -->
@@ -18,3 +18,10 @@ if (!document.querySelector('meta[name="htmx-config"]'))
 
 <!-- Session-expiry redirect guard for HTMX-based LCTable requests -->
 <script src="${pageContext.request.contextPath}/js/htmx-session-expiry-guard.js"></script>
+
+<!-- Small LCTable client-side helpers, currently:
+         - viewport-edge-aware popup positioning
+         - custom tooltips for icon-only action links
+         - stripping of empty-value request parameters from LCTable-issued HTMX requests -->
+<script src="${pageContext.request.contextPath}/includes/lctable/lctable.js"></script>
+

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/findSubjects.jsp
@@ -11,25 +11,41 @@
 <!-- move the alert message to the sidebar-->
 <jsp:include page="../include/sideAlert.jsp"/>
 
-<link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
+<%-- JMesa scripts are only needed when the JMesa rendering path is active. --%>
+<c:choose>
+    <c:when test="${tableRenderingMode == 'jmesa'}">
+        <link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
+    </c:when>
+    <c:otherwise>
+        <link rel="stylesheet" href="includes/lctable/lctable.css" type="text/css">
+    </c:otherwise>
+</c:choose>
 
+<!-- jquery.min.js and jquery.blockUI.js are needed unconditionally: jQuery/blockUI power the
+     "Add New Subject" modal overlay (see the jQuery(document).ready(...) block below), unrelated to jmesa -->
 <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa.js"></script>
 <script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery.blockUI.js"></script>
-<script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery-migrate-3.4.1.min.js"></script>
+
+<c:if test="${tableRenderingMode == 'jmesa'}">
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa.js"></script>
+    <script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery-migrate-3.4.1.min.js"></script>
+
+    <script type="text/javascript">
+        function onInvokeAction(id,action) {
+            if(id.indexOf('findSubjects') == -1)  {
+            setExportToLimit(id, '');
+            }
+            createHiddenInputFieldsForLimitAndSubmit(id);
+        }
+        function onInvokeExportAction(id) {
+            var parameterString = createParameterStringForLimit(id);
+            location.href = '${pageContext.request.contextPath}/ListStudySubjects?'+ parameterString;
+        }
+    </script>
+</c:if>
 
 <script type="text/javascript">
-    function onInvokeAction(id,action) {
-        if(id.indexOf('findSubjects') == -1)  {
-        setExportToLimit(id, '');
-        }
-        createHiddenInputFieldsForLimitAndSubmit(id);
-    }
-    function onInvokeExportAction(id) {
-        var parameterString = createParameterStringForLimit(id);
-        location.href = '${pageContext.request.contextPath}/ListStudySubjects?'+ parameterString;
-    }
     $.noConflict();			// to avoid conflicts with prototype.js
 	jQuery(document).ready(function() {
 		// add a listener to the add subject link
@@ -74,11 +90,33 @@
 
 <h1><span class="title_manage"><fmt:message key="view_subjects_in" bundle="${restext}"/> <c:out value="${study.name}"/></span></h1>
 
+<%-- The "Select an Event"/"Add New Subject" toolbar controls used to be rendered directly here (for the
+     htmlflow rendering path only -- the legacy jmesa rendering path always rendered its own equivalent
+     controls as part of the jmesa table itself, via ListStudySubjectTableToolbar). They are now rendered
+     as custom toolbar controls of the LCTable itself for the htmlflow path too -- see LCTable's
+     addCustomToolbarControl / ListStudySubjectTable -- so no separate markup is needed here any more. --%>
+
 <div id="findSubjectsDiv">
-	<form  action="${pageContext.request.contextPath}/ListStudySubjects">
-		<input type="hidden" name="module" value="admin">
-		${findSubjectsHtml}
-	</form>
+	<%-- IMPORTANT: the LCTable (HtmlFlow) rendering path renders its own <form> around the whole
+	     table (see LCTable.renderTableHtml()) -- it must NOT also be wrapped in a <form> here, or
+	     the browser will treat the two nested <form>s as a single merged form (nested <form>s are
+	     invalid HTML; the inner start tag is simply dropped by the parser), causing any hidden
+	     input declared in *this* JSP (e.g. a hardcoded "module") to collide with LCTable's own
+	     same-named hidden inputs (e.g. a "module" sticky parameter) once both are serialized
+	     together by HTMX's "closest form" -- see LCTable's class-level javadoc for details.
+	     Only the legacy JMesa rendering path (native form-based pagination/sort/filter resubmission,
+	     via createHiddenInputFieldsForLimitAndSubmit()) actually needs a surrounding <form>. --%>
+	<c:choose>
+		<c:when test="${tableRenderingMode == 'jmesa'}">
+			<form action="${pageContext.request.contextPath}/ListStudySubjects">
+				<input type="hidden" name="module" value="admin">
+				${findSubjectsHtml}
+			</form>
+		</c:when>
+		<c:otherwise>
+			${findSubjectsHtml}
+		</c:otherwise>
+	</c:choose>
 </div>
 
 <!-- compose the overlay to add new subject, but don't show it-->
@@ -87,5 +125,8 @@
 </div>
 
 <br />
+
+<!-- Include everything that is needed for proper use of HTMX with LCTable -->
+<jsp:include page="../include/useLCTable.jsp"/>
 
 <jsp:include page="../include/footer.jsp"/>

--- a/web/src/main/webapp/WEB-INF/jsp/menu.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/menu.jsp
@@ -17,11 +17,24 @@
 
 <jsp:include page="include/sideAlert.jsp"/>
 
-<script type="text/JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
-<script type="text/JavaScript" src="includes/jmesa/jmesa.js"></script>
-<script type="text/javascript" src="includes/jmesa/jquery.blockUI.js"></script>
+<%-- The studySiteStatistics/studyStatistics/subjectEventStatusStatistics/studySubjectStatusStatistics
+     tables (coordinator/director) and the sdvMatrix table (monitor) are still rendered with JMesa
+     regardless of LC_TABLE_RENDERING -- only the findSubjects table (investigator/RA/RA2) has been
+     migrated to LCTable/HtmlFlow. So the JMesa assets must load whenever any JMesa-rendered table
+     may appear on this page, not just when findSubjects itself uses the JMesa path. --%>
+<c:set var="needsJmesaAssets" value="${tableRenderingMode == 'jmesa' || userRole.coordinator || userRole.director || userRole.monitor}"/>
+<c:if test="${needsJmesaAssets}">
+    <script type="text/JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
+    <script type="text/JavaScript" src="includes/jmesa/jmesa.js"></script>
+    <link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
+</c:if>
+<c:if test="${tableRenderingMode == 'htmlflow'}">
+    <link rel="stylesheet" href="includes/lctable/lctable.css" type="text/css">
+</c:if>
 
-<link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
+<!-- jquery.blockUI.js is needed unconditionally: jQuery/blockUI power the "Add New Subject" modal
+     overlay, unrelated to jmesa -->
+<script type="text/javascript" src="includes/jmesa/jquery.blockUI.js"></script>
 
 <!-- warning is study is frozen or locked -->
 <div id="box" class="dialog">
@@ -80,17 +93,21 @@
 
 <c:if test="${userRole.investigator || userRole.researchAssistant || userRole.researchAssistant2}"> <!-- if investigator, research assistant or ra2 -->
 	<div id="findSubjectsDiv">
-    <script type="text/javascript">
-    function onInvokeAction(id,action) {
-        if(id.indexOf('findSubjects') == -1)  {
-        setExportToLimit(id, '');
+    <c:if test="${tableRenderingMode == 'jmesa'}">
+        <script type="text/javascript">
+        function onInvokeAction(id,action) {
+            if(id.indexOf('findSubjects') == -1)  {
+            setExportToLimit(id, '');
+            }
+            createHiddenInputFieldsForLimitAndSubmit(id);
         }
-        createHiddenInputFieldsForLimitAndSubmit(id);
-    }
-    function onInvokeExportAction(id) {
-        var parameterString = createParameterStringForLimit(id);
-        location.href = '${pageContext.request.contextPath}/MainMenu?'+ parameterString;
-    }
+        function onInvokeExportAction(id) {
+            var parameterString = createParameterStringForLimit(id);
+            location.href = '${pageContext.request.contextPath}/MainMenu?'+ parameterString;
+        }
+        </script>
+    </c:if>
+    <script type="text/javascript">
     jQuery(document).ready(function() {
         jQuery('#addSubject').click(function() {
             jQuery.blockUI({ message: jQuery('#addSubjectForm'), css:{left: "300px", top:"10px" } });
@@ -102,10 +119,21 @@
         });
     });
     </script>
-    <form  action="${pageContext.request.contextPath}/ListStudySubjects">
-        <input type="hidden" name="module" value="admin">
-        ${findSubjectsHtml}
-    </form>
+    <%-- IMPORTANT: the LCTable (HtmlFlow) rendering path renders its own <form> around the whole
+         table (see LCTable.renderTableHtml()) -- it must NOT also be wrapped in a <form> here, or
+         the nested <form>s would collide (see managestudy/findSubjects.jsp for a full explanation).
+         Only the legacy JMesa rendering path needs a surrounding <form>. --%>
+    <c:choose>
+        <c:when test="${tableRenderingMode == 'jmesa'}">
+            <form  action="${pageContext.request.contextPath}/ListStudySubjects">
+                <input type="hidden" name="module" value="admin">
+                ${findSubjectsHtml}
+            </form>
+        </c:when>
+        <c:otherwise>
+            ${findSubjectsHtml}
+        </c:otherwise>
+    </c:choose>
 </div>
     <div id="addSubjectForm" style="display:none;">
          <c:import url="addSubjectMonitor.jsp"/>
@@ -210,6 +238,9 @@
 		</form>
 	</div>
 </c:if>
+
+<!-- Include everything that is needed for proper use of HTMX with LCTable -->
+<jsp:include page="include/useLCTable.jsp"/>
 
 <!-- end of menu.jsp -->
 <jsp:include page="include/footer.jsp"/>

--- a/web/src/main/webapp/includes/lctable/lctable.css
+++ b/web/src/main/webapp/includes/lctable/lctable.css
@@ -1,6 +1,6 @@
 /*
  * derived from jmesa.css, adapted to fit LCTable needs
- * '.lctable' use to be '.jmesa'
+ * (note: '.lctable' used to be '.jmesa')
  */
 
 .lctable {
@@ -30,13 +30,33 @@
     padding: 0;
 }
 
-.toolbar table {
+.lctable .toolbar table {
     margin-right: auto;
     margin-left: 0px;
 }
 
 .lctable .toolbar {
     user-select: none;
+}
+
+.lctable .toolbar-container {
+    display: flex;
+    align-items: center;
+    gap: 0;
+}
+
+.lctable .toolbar-separator {
+    border-left: 1px solid #c0c0c0;
+    height: 1.2em;
+    margin: 0 6px;
+}
+
+.lctable .dropdown-list {
+    margin: 0;
+}
+
+.lctable .dropdown-list label {
+    color: black;
 }
 
 .lctable .toolbar td {
@@ -121,72 +141,13 @@
 }
 
 
-.lctable .tbody input {
-    padding: 0;
-    margin: 0;
-}
-
-.lctable .filter .dynFilter {
-    position: relative;
-    font-family: verdana, arial, helvetica, sans-serif;
-    font-size: 11px;
-    padding: 0;
-    margin: 0;
-    border: 1px solid #c0c0c0;
-    background-color: var(--gray-l30);
-    height: 15px;
-    white-space: nowrap;
-    cursor: pointer;
-    z-index: 4;
-}
-
-.lctable .filter #dynFilterDiv {
-    position: absolute;
-    top: -3px;
-    left: -2px;
-    padding: 0;
-    margin: 0;
-    height: 17px;
-    border: 1px solid #c0c0c0;
-    background-color: #e1ebf4;
-}
-
-.lctable .filter #dynFilterInput {
-    font-family: verdana, arial, helvetica, sans-serif;
-    font-size: 12px;
-    padding: 0;
-    margin: 0;
-    border-style: none;
-    background-color: #e1ebf4;
-}
-
-.lctable .filter #dynFilterDroplistDiv {
-    position: absolute;
-    top: -2px;
-    left: -2px;
-    padding: 0;
-    margin: 0;
-    height: 17px;
-    background-color: #e1ebf4;
-    z-index: 4;
-}
-
-.lctable .filter #dynFilterDroplist {
-    font-family: verdana, arial, helvetica, sans-serif;
-    font-size: 12px;
-    padding: 0;
-    margin: 0;
-    border: 1px solid #c0c0c0;
-    background-color: #e1ebf4;
-}
-
 .lctable .header {
 	height: 15px;
 	max-height:30px
 }
 
 .lctable .header th {
-    white-space: nowrap;
+    white-space: normal;
     background-color: var(--lightblue-d20);
     color: white;
     font-family: verdana, arial, helvetica, sans-serif;
@@ -201,7 +162,7 @@
 }
 
 .lctable .header td {
-    white-space: nowrap;
+    white-space: normal;
     background-color: white;
     color: white;
     font-size: 11px;
@@ -215,6 +176,65 @@
 
 .lctable .odd a, .lctable .even a {
     color: black;
+}
+
+/*
+ * Icon action links (View/Remove/Restore/... in the Actions column, and the analogous links inside
+ * the event-detail popup). The global "a:hover, a:active { text-decoration: underline; }" rule
+ * (includes/styles.css) is not appropriate for these icon-only/icon+label links, so it is overridden
+ * here; a small right-margin also gives them a bit more breathing room than plain adjacency (loosely
+ * modelled on the legacy jmesa table's "&nbsp;&nbsp;&nbsp;" spacing between action links).
+ */
+.lctable .action-link {
+    text-decoration: none;
+    margin-right: 2px;
+}
+
+.lctable .action-link:last-child {
+    margin-right: 0;
+}
+
+.lctable .action-link:hover, .lctable .action-link:active {
+    text-decoration: none;
+}
+
+/*
+ * The hover/focus tooltip itself (shown only for icon-only action links, i.e. "data-tooltip" is set --
+ * see LCTableUtil.actionLink()) is implemented in lctable.js as a single reusable ".lc-tooltip" element
+ * appended directly to <body> and positioned with "position: fixed" from the hovered/focused element's
+ * getBoundingClientRect(), rather than as a pure-CSS "::after" bubble anchored to the link itself.
+ * This deliberately avoids two problems a "::after" bubble would have here:
+ *  - it would depend on the native browser per-window hover-timer machinery behaving consistently
+ *    (which -- for the native "title" attribute this replaces -- is known to stop reliably reappearing
+ *    once the browser window has lost and regained focus);
+ *  - being a descendant of the scrollable ".event-popup-body", it would get silently clipped by that
+ *    ancestor's "overflow-y: auto" whenever there wasn't enough room below/above within the *scrollable
+ *    container* (which is exactly what happened for the last occurrence's actions, and the last action
+ *    in the non-repeating vertical layout: the tooltip had no clipped-free space left below them).
+ * A "position: fixed" element appended to <body> is not a descendant of that scrolling container at all,
+ * so it is never clipped by it, regardless of which row/action is hovered.
+ */
+.lc-tooltip {
+    position: fixed;
+    z-index: 10000;
+    background: var(--lightblue-d20);
+    color: #fff;
+    font-family: verdana, arial, helvetica, sans-serif;
+    font-size: 12px;
+    font-weight: normal;
+    padding: 5px 9px;
+    border-radius: 6px;
+    white-space: nowrap;
+    box-shadow: 1px 2px 5px rgba(0, 0, 0, 0.4);
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.1s ease;
+}
+
+.lc-tooltip.lc-tooltip-visible {
+    opacity: 1;
+    visibility: visible;
 }
 
 /* Prevent inline-baseline gap below images in table cells */
@@ -260,126 +280,12 @@
     padding: 2px;
 }
 
-.lctable .dropShadow {
-    padding: 10px 14px 14px 10px;
-}
-
-.lctable .wsColumn {
-    position: relative;
-    font-family: verdana, arial, helvetica, sans-serif;
-    font-size: 11px;
-    padding: 0;
-    margin: 0;
-    border-bottom: 1px solid #c0c0c0;
-    height: 15px;
-    white-space: nowrap;
-    cursor: pointer;
-}
-
-.lctable .wsColumnError {
-    position: relative;
-    font-family: verdana, arial, helvetica, sans-serif;
-    font-size: 11px;
-    font-style: italic;
-    padding: 0;
-    margin: 0;
-    color: #ec4646;
-    border-bottom: 1px dashed #ec4646;
-    height: 15px;
-    white-space: nowrap;
-    cursor: pointer;
-}
-
-.lctable .wsColumnChange {
-    position: relative;
-    font-family: verdana, arial, helvetica, sans-serif;
-    font-size: 11px;
-    font-style: italic;
-    padding: 0;
-    margin: 0;
-    color: #005e8f;
-    border-bottom: 1px dashed #005e8f;
-    height: 15px;
-    white-space: nowrap;
-    cursor: pointer;
-}
-
-.lctable #wsColumnDiv {
-    position: absolute;
-    top: -2px;
-    left: -2px;
-    padding: 0;
-    margin: 0;
-    height: 17px;
-    border: 1px solid #c0c0c0;
-    background-color: #ededed;
-}
-
-.lctable #wsColumnInput {
-    font-family: verdana, arial, helvetica, sans-serif;
-    font-size: 12px;
-    padding: 0;
-    margin: 0;
-    border-style: none;
-    background-color: #ededed;
-}
-
-/*
- * KK - Added new configuration to support popups inside the table rows.
- */
-
-.lctable .ViewSubjectsPopup td, .lctable .highlight .ViewSubjectsPopup td {
-	background-color: #FFFFE5;
-    border-style: solid;
-    border-width: 0px 0px 0px 0px;
-    border-color: #CCCCCC;
-    padding: 0px;
-    }
-
-.lctable .ViewSubjectsPopup td.table_header_row_left, .lctable .highlight .ViewSubjectsPopup td.table_header_row_left {
-   padding: 3px 1px 3px 6px;
-   border-style: solid;
-   border-width: 0px 0px 1px 0px;
-   border-color: #CCCCCC;
-   font-weight: bold;
-   color: #666666;
-   vertical-align: top;
-}
-
-.lctable .ViewSubjectsPopup td.table_header_row, .lctable .highlight .ViewSubjectsPopup td.table_header_row {
-	padding: 3px 1px 3px 2px;
-    border-style: solid;
-    border-width: 0px 0px 1px 1px;
-    border-color: #CCCCCC;
-    font-weight: bold;
-    color: #666666;
-    vertical-align: top;
-    }
-
-.lctable .ViewSubjectsPopup td.table_cell_left, .lctable .highlight .ViewSubjectsPopup td.table_cell_left, .lctable .ViewSubjectsPopup td.table_cell, .lctable .highlight .ViewSubjectsPopup td.table_cell {
-	padding: 3px 1px 3px 2px;
-    border-style: solid;
-    border-width: 1px 0px 0px 1px;
-    border-top-color: #E6E6E6;
-    border-left-color: #CCCCCC;
-    vertical-align: top;
-    }
-
-.lctable .ViewSubjectsPopup td.statusbox_scroll_R_dis, .lctable .highlight td.ViewSubjectsPopup.statusbox_scroll_R_dis {
-	border-style: solid;
-    border-width: 0px 0px 0px 1px;
-    border-color: #CCCCCC;
-    }
-
-.lctable .ViewSubjectsPopup td a, .lctable .highlight .ViewSubjectsPopup td a {
-	color: #789EC5;
-	}
-
 
 /* ---- additions for LCTable ---- */
 
-.lctable .page-btn {
+.lctable .text-btn {
     display: inline-block;
+    white-space: nowrap;
     padding: 2px 6px;
     border: 1px solid #ddd;
     border-radius: 0;
@@ -392,28 +298,14 @@
     text-align: center;
 }
 
-.page-btn {
-    display: inline-block;
-    padding: 2px 6px;
-    border: 1px solid #ddd;
-    border-radius: 0;
-    text-decoration: none;
-    color: #333;
-    background: #fff;
-    cursor: pointer;
-    font-size: 0.75rem;
-    min-width: 1.5em;
-    text-align: center;
-}
-
-.page-btn:hover              { background: #eee; }
-.page-btn.current            { background: #2563eb; color: #fff; border-color: #2563eb; }
-.page-btn.disabled           { color: #bbb; pointer-events: none; cursor: default; }
-.page-btn, .page-ellipsis    { user-select: none; }
-.page-ellipsis               { display: inline-block; min-width: 1.2em; padding: 2px 6px; color: #888; font-size: 0.65rem; text-align: center; }
+.lctable .text-btn:hover              { background: #eee; }
+.lctable .text-btn.current            { background: #2563eb; color: #fff; border-color: #2563eb; }
+.lctable .text-btn.disabled           { color: #bbb; pointer-events: none; cursor: default; }
+.lctable .text-btn, .lctable .page-ellipsis    { user-select: none; }
+.lctable .page-ellipsis               { display: inline-block; min-width: 1.2em; padding: 2px 6px; color: #888; font-size: 0.65rem; text-align: center; }
 
 /* Sort header styling */
-.sort-header-link {
+.lctable .sort-header-link {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -423,15 +315,172 @@
     cursor: pointer;
 }
 
-.sort-header-text {
+.lctable .sort-header-text {
     flex: 1;
 }
 
-.sort-indicator {
+.lctable .sort-indicator {
     display: block;
     width: auto;
     height: auto;
     flex-shrink: 0;
+}
+
+/*
+ * Event-detail hover/focus popup (findSubjects "Subject Matrix" table).
+ * Simplified, pure-CSS replacement for the legacy absolute-positioned <div> + inline-JS popup:
+ * all occurrences are always rendered, and only the popup *body* scrolls internally (the header,
+ * including the "add another occurrence" button, stays fixed at the top) -- no left/right occurrence
+ * "scroller", no onmouseover/onclick JS. The only JS involved (see lctable.js) flips the popup to
+ * right-align with its trigger when it would otherwise overflow past the right edge of the viewport.
+ */
+.lctable .event-trigger {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+}
+
+.lctable .event-status-badge {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 6px;
+}
+
+.lctable .event-status-badge:last-child {
+    margin-right: 0;
+}
+
+.lctable .event-popup {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 50;
+    flex-direction: column;
+    /*
+     * Explicit "width: max-content" (rather than leaving width as the "auto" default) is essential
+     * here: since this is an absolutely-positioned box whose containing block is the small
+     * ".event-trigger" (sized to fit just the status icon(s)), an "auto" width would be computed via
+     * the CSS2.1 shrink-to-fit algorithm using that tiny containing block as the "available width" --
+     * which clamps the box down near the trigger's own width regardless of max-width, making max-width
+     * changes appear to have no effect. "max-content" instead sizes the box to its own content's
+     * preferred (unwrapped) width, still properly clamped by min-width/max-width below.
+     */
+    width: max-content;
+    min-width: 220px;
+    max-width: 500px;
+    max-height: 260px;
+    overflow: hidden;
+    text-align: left;
+    white-space: normal;
+    box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+/* Added by lctable.js when the popup would otherwise overflow past the right edge of the viewport. */
+.lctable .event-popup.lc-popup-align-right {
+    left: auto;
+    right: 0;
+}
+
+.lctable .event-trigger:hover .event-popup,
+.lctable .event-trigger:focus-within .event-popup {
+    display: flex;
+}
+
+.lctable .event-popup-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+    flex: 0 0 auto;
+}
+
+/* Prevent "Subject: ..."/"Event: ..." from wrapping onto a second line: since the popup has no
+   explicit width, letting this text wrap would shrink it below its natural (unwrapped) width. */
+.lctable .event-popup-header-text {
+    white-space: nowrap;
+}
+
+.lctable .event-popup-header .text-btn {
+    flex-shrink: 0;
+}
+
+.lctable .event-popup-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    min-height: 0;
+}
+
+/*
+ * "Hybrid" per-occurrence row layouts (see ListStudySubjectTable#renderPopupBody and friends):
+ *  - non-repeating events (and events with no occurrence yet): "simple" layout, one action per line,
+ *    each with icon + text label -- ".event-occurrence-row" without the "-compact" modifier.
+ *  - repeating events (with at least one occurrence): "compact" layout, two lines per occurrence
+ *    ("Occurrence #i of N · date · status" then "Actions: " + icon-only links) --
+ *    ".event-occurrence-row.event-occurrence-row-compact".
+ * In both cases, ".event-occurrence-row" is the hoverable/highlightable unit (the "row" the user
+ * points at). A subtle border/box gives each occurrence a permanent, "passive" visual grouping (a bit
+ * more pronounced than the thin lines separating the 1-2 lines *within* one occurrence), on top of
+ * which hovering adds a slightly darker shade of the popup's pale-yellow background.
+ */
+.lctable .event-occurrence-row {
+    margin: 3px 4px;
+    padding: 3px 4px;
+    border: 1px solid #E0D9A0;
+    border-radius: 3px;
+}
+
+.lctable .event-occurrence-row:hover {
+    background-color: #F5EEA0;
+    border-color: #C9BC66;
+}
+
+.lctable .event-occurrence-row .table_cell_left,
+.lctable .event-occurrence-row .table_cell {
+    border-left: none;
+}
+
+.lctable .event-occurrence-row > div:first-child {
+    border-top: none;
+}
+
+.lctable .event-status-icon-inline {
+    vertical-align: middle;
+    margin: 0 2px;
+}
+
+/* Simple (non-repeating) layout: one action per line, icon + text label, with a little breathing room
+   between lines (both visually clearer and easier to click precisely). */
+.lctable .occurrence-actions-vertical a {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    white-space: nowrap;
+    margin-bottom: 4px;
+}
+
+.lctable .occurrence-actions-vertical a:last-child {
+    margin-bottom: 0;
+}
+
+/* Compact (repeating) layout: "Actions: " label followed by icon-only links, all on one line. */
+.lctable .occurrence-actions-compact {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+.lctable .occurrence-actions-compact a {
+    display: inline-flex;
+    align-items: center;
+}
+
+.lctable .event-occurrence-row .occurrence-actions img,
+.lctable .event-occurrence-row .occurrence-summary-line img {
+    vertical-align: middle;
 }
 
 /* Hover highlight for rows: match jmesa .highlight appearance exactly */

--- a/web/src/main/webapp/includes/lctable/lctable.js
+++ b/web/src/main/webapp/includes/lctable/lctable.js
@@ -1,0 +1,186 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+
+ * For details see: https://libreclinica.org/license
+ * copyright (C) 2026 LibreClinica
+ */
+
+/*
+ * LCTable client-side helpers.
+ *
+ * Filtering/sorting/pagination themselves are all handled server-side via HTMX (see useLCTable.jsp) --
+ * most of this file only contains small, purely-cosmetic DOM helpers that cannot reasonably be done
+ * in pure CSS. The one exception is the "strip empty parameters" listener directly below, which is a
+ * necessary client-side companion to the URL clean-up done in LCTable.java (see LCTable.url()).
+ *
+ * "Smart" popup positioning: an LCTable popup (e.g. the findSubjects event-detail popup) is
+ * normally left-aligned with its trigger element (class "lc-popup-trigger", containing a child
+ * element with class "lc-popup"). If left-aligning it would make it overflow past the right edge
+ * of the viewport, this flips it to right-align with the trigger instead (class "lc-popup-align-right"),
+ * so the popup never gets truncated/cut off by the browser window edge.
+ */
+(function () {
+    function repositionIfNeeded(trigger) {
+        var popup = trigger.querySelector('.lc-popup');
+        if (!popup) return;
+        // Reset first, then re-measure: the trigger/popup may be reused (e.g. after an HTMX
+        // morph-swap of the table), and the previous viewport width/scroll position may no longer apply.
+        popup.classList.remove('lc-popup-align-right');
+        if (popup.getBoundingClientRect().right > window.innerWidth) {
+            popup.classList.add('lc-popup-align-right');
+        }
+    }
+
+    // Event delegation on 'document' (capture phase) so this works for any current or future
+    // '.lc-popup-trigger' element, without needing to attach a listener to each one individually.
+    document.addEventListener('mouseover', function (event) {
+        var trigger = event.target.closest('.lc-popup-trigger');
+        if (trigger) repositionIfNeeded(trigger);
+    }, true);
+
+    document.addEventListener('focusin', function (event) {
+        var trigger = event.target.closest('.lc-popup-trigger');
+        if (trigger) repositionIfNeeded(trigger);
+    }, true);
+})();
+
+/*
+ * Strip empty-valued request parameters from LCTable-issued HTMX requests.
+ *
+ * LCTable.java's own URL builder (LCTable.url(), used for pagination/sort/"Show More" links) already
+ * omits null/empty parameters (e.g. it will never emit "sortProp=" or "showHiddenCols="): see the
+ * javadoc on LCTable.url() for the rationale. However, *not every* LCTable-issued request goes through
+ * that builder: the maxRows <select> and the filter inputs/selects (see LCTableFilterDef) instead use
+ * HTMX's own "hx-include" mechanism (e.g. hx-include="closest form") to gather the current values of
+ * sibling form controls -- this is plain HTMX/browser form serialisation, entirely bypassing
+ * LCTable.url(), and it naively submits every named form control's current value, blank or not. Two
+ * concrete sources of blank values:
+ *  - filter <input>/<select> elements are always rendered (the user needs to see/use them, whether or
+ *    not they currently hold a value), so an untouched filter legitimately serialises as "q.foo=";
+ *  - LCTable.java only renders the sortProp/sortDir/showHiddenCols hidden inputs when they hold a
+ *    non-default value (mirroring the same rationale as url()), which handles most cases, but doesn't
+ *    (and can't) help with the filter inputs above.
+ *
+ * Rather than duplicating LCTable.url()'s clean-up logic in every hx-include selector (fragile, and
+ * impossible for the always-rendered filter inputs), this single, generic listener removes any
+ * empty-string parameter right before HTMX builds the request, for every request that originates from
+ * inside an ".lctable" panel. This keeps the resulting (and pushed, see hx-push-url) URL clean
+ * regardless of which mechanism (Java-built href, or HTMX form serialisation) produced it, without
+ * changing which parameters are considered "empty" server-side (LCTableParams already treats a missing
+ * parameter the same as an empty one).
+ */
+document.body.addEventListener('htmx:configRequest', function (event) {
+    if (!event.target.closest || !event.target.closest('.lctable')) return;
+    var params = event.detail.parameters;
+    if (!params) return;
+    Object.keys(params).forEach(function (key) {
+        var value = params[key];
+        if (Array.isArray(value)) {
+            // repeated parameter name: drop only the blank entries, drop the whole key if nothing is left
+            value = value.filter(function (v) { return v !== '' && v != null; });
+            if (value.length === 0) {
+                delete params[key];
+            } else {
+                params[key] = value;
+            }
+        } else if (value === '' || value == null) {
+            delete params[key];
+        }
+    });
+});
+
+
+
+/*
+ * Custom tooltip for icon-only action links (elements with a "data-tooltip" attribute -- see
+ * LCTableUtil.actionLink()), replacing the native "title"-attribute tooltip.
+ *
+ * Two problems with relying on the native title tooltip (and, before this, on a pure-CSS "::after"
+ * bubble anchored to the link itself) motivated this:
+ *  - the browser's native per-window title-tooltip hover timer is known to stop reliably reappearing
+ *    once the browser window has lost and regained focus;
+ *  - a "::after" bubble, being a descendant of a scrolling ancestor (the event-detail popup's
+ *    scrollable body), would get silently clipped by that ancestor's "overflow-y: auto" whenever there
+ *    wasn't enough room left within the *scrollable container* -- which is exactly what happened for
+ *    the last occurrence's actions (nothing below them to give the downward-pointing bubble room).
+ *
+ * The fix: a single reusable tooltip element ("#lc-tooltip"), created once and appended directly to
+ * <body> (i.e. NOT a descendant of any scrolling/clipping ancestor), positioned with "position: fixed"
+ * from the hovered/focused element's getBoundingClientRect(). This can never be clipped by an ancestor,
+ * regardless of which row/action triggered it, and does not depend on any native per-window timer.
+ */
+(function () {
+    var tooltipEl = null;
+
+    function getTooltipEl() {
+        if (!tooltipEl) {
+            tooltipEl = document.createElement('div');
+            tooltipEl.className = 'lc-tooltip';
+            tooltipEl.setAttribute('id', 'lc-tooltip');
+            document.body.appendChild(tooltipEl);
+        }
+        return tooltipEl;
+    }
+
+    function positionTooltip(target, el) {
+        var targetRect = target.getBoundingClientRect();
+        var tipRect = el.getBoundingClientRect();
+        var gap = 6;
+
+        // prefer below the target; flip above it if there is not enough room below the viewport
+        var top = targetRect.bottom + gap;
+        if (top + tipRect.height > window.innerHeight) {
+            top = targetRect.top - tipRect.height - gap;
+        }
+        top = Math.max(2, top);
+
+        // center horizontally on the target, clamped to stay within the viewport
+        var left = targetRect.left + (targetRect.width / 2) - (tipRect.width / 2);
+        left = Math.max(2, Math.min(left, window.innerWidth - tipRect.width - 2));
+
+        el.style.top = top + 'px';
+        el.style.left = left + 'px';
+    }
+
+    function showTooltip(target) {
+        var text = target.getAttribute('data-tooltip');
+        if (!text) return;
+        var el = getTooltipEl();
+        el.textContent = text;
+        el.classList.add('lc-tooltip-visible');
+        positionTooltip(target, el);
+    }
+
+    function hideTooltip() {
+        if (tooltipEl) tooltipEl.classList.remove('lc-tooltip-visible');
+    }
+
+    document.addEventListener('mouseover', function (event) {
+        var target = event.target.closest('[data-tooltip]');
+        if (target) showTooltip(target);
+    }, true);
+
+    document.addEventListener('mouseout', function (event) {
+        var target = event.target.closest('[data-tooltip]');
+        // don't hide if the pointer merely moved onto a descendant of the same tooltipped element
+        if (target && (!event.relatedTarget || !target.contains(event.relatedTarget))) hideTooltip();
+    }, true);
+
+    document.addEventListener('focusin', function (event) {
+        var target = event.target.closest('[data-tooltip]');
+        if (target) showTooltip(target);
+    }, true);
+
+    document.addEventListener('focusout', function (event) {
+        var target = event.target.closest('[data-tooltip]');
+        if (target) hideTooltip();
+    }, true);
+
+    // A tooltip's position is only computed once, when it is shown: if the user scrolls (e.g. the
+    // event-detail popup's internal body) while it is visible, just hide it rather than letting it
+    // float, stale, over unrelated content.
+    window.addEventListener('scroll', hideTooltip, true);
+})();
+
+


### PR DESCRIPTION
First working implementation of LCTable-based `findSubjects` table replacing the corresponding legacy jmesa table (see https://github.com/reliatec-gmbh/LibreClinica/issues/74).

Note: this is the second migrated jmesa table. It is configured by the `ListStudySubjectTable` class and is part of the "Subject Matrix" (see also https://github.com/reliatec-gmbh/LibreClinica/wiki/jmesa-tables-migration:-progress-and-to-do).

Details of main new features, additions and modifications:

1. `findSubjects` table:
    - `ListStudySubjectTable`: new class for configuring the `findSubjects` table
    - `FindSubjectRows`: new class for strongly-typed definition of the data record corresponding to a row of the table
    - `ListStudySubjectServlet`, `MainMenuServlet`: servlet classes modified to invoke the generation of the table (when LC_TABLE_RENDERING is not `jmesa` and under the appropriate conditions, e.g. concerning roles)
    - `findSubjects.jsp`, `menu.jsp`: JSP templates modified to include the HTML generated for the table into the JSP templates for the pages containing the table (under the conditions mentioned above)

2. LCTable library:
    - new `SafeUrl` class that automatically escapes parameter values: this class is now used to safely specify the target URLs of all "action links" occurring in the tables (see definition of `actionLink` method in `LCTableUtil` and all `actionLinks` calls)
    - add HTML `id` attributes to all "interactable" UI elements of tables (buttons, filters, clickable headers of sortable columns, action links): see `LCTable` class as well as the concrete table classes `AuditUserLogin` and `ListStudySubjectTable`
    - added "hidden columns" feature and additional URL parameter `showHiddenColumns` to make the hidden columns (temporarily) visible
    - added "sticky parameters": these are URL parameters (e.g. `defId`) that are not related to the table's state, but must be preserved across all table interactions (pagination, sorting, filtering), and are declared in a "whitelist" of the table, so that they are "forwarded" unchanged into new requests (note: any parameters that are neither table-related nor in the whitelist will be dropped; furthermore, the "sticky parameters" appear in the URL before the table-related parameters)
    - request parameters which are null or have an empty value are now omitted from the URL

3. Client-side features:
    - various modifications / improvements in `lctable.css`
    - new JavaScript file `lctable.js` implementing certain client-side functionality needed by the LCTable library (viewport-edge-aware popup positioning; custom tooltips for icon-only action links; stripping of empty-value request parameters from LCTable-issued HTMX request)

4. JSP fragment previously called `useHtmx.jsp` extended to include `lctable.js` into any JSP template where an LCTable appears, and renamed to `useLCTable.jsp` to better reflect its purpose
