### PR TITLE
Fix the UI path that enables randomization (follow-up to #452)

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/domain/rule/action/RandomizeActionProcessor.java
+++ b/core/src/main/java/org/akaza/openclinica/domain/rule/action/RandomizeActionProcessor.java
@@ -19,6 +19,10 @@
  *   - Ported from OpenClinica v3.x; date: 2026-03-11 - 2026-03-12.
  *   - Source content compatible as-is with LibreClinica
  *     (OpenClinica source does not reference SAVE_AND_GO_NEXT).
+ *   - mayProceed: compare the study and site status with Status.AVAILABLE
+ *     instead of comparing Term.getName() with the English literal
+ *     "available". getName() returns the translated term, so the gate never
+ *     opened on a non-English UI locale and the action did nothing.
  *
  * License selection:
  *   The OpenClinica original was licensed under LGPL v2.1 or later.
@@ -136,12 +140,17 @@ public class RandomizeActionProcessor implements ActionProcessor {
         String randomizationStatusFromOCUI = seRandomizationDTO.getStatus();
 
         String randomizationStatusFromOC = pStatus.getValue().toString();
-        String studyStatus = study.getStatus().getName().toString();
-        String siteStatus = siteStudy.getStatus().getName().toString();
-        logger.info("randomizationStatusFromOCUI: {}  randomizationStatusFromOC: {}  studyStatus: {}  siteStatus: {}",
-                randomizationStatusFromOCUI, randomizationStatusFromOC, studyStatus, siteStatus);
-        if (randomizationStatusFromOC.equalsIgnoreCase("enabled") && studyStatus.equalsIgnoreCase("available")
-                && siteStatus.equalsIgnoreCase("available") && randomizationStatusFromOCUI.equalsIgnoreCase("ACTIVE")) {
+        // Modified: Term.getName() resolves the term through the terms resource bundle, so it
+        // returns the *translated* name. Comparing it with the English literal "available" made
+        // this gate fail for every non-English UI locale, and the action then did nothing without
+        // raising anything. The study parameter and the module status are raw values and stay as
+        // they are; only the two status checks compare the status itself.
+        boolean studyAvailable = Status.AVAILABLE.equals(study.getStatus());
+        boolean siteAvailable = Status.AVAILABLE.equals(siteStudy.getStatus());
+        logger.info("randomizationStatusFromOCUI: {}  randomizationStatusFromOC: {}  studyAvailable: {}  siteAvailable: {}",
+                randomizationStatusFromOCUI, randomizationStatusFromOC, studyAvailable, siteAvailable);
+        if (randomizationStatusFromOC.equalsIgnoreCase("enabled") && studyAvailable && siteAvailable
+                && randomizationStatusFromOCUI.equalsIgnoreCase("ACTIVE")) {
             accessPermission = true;
         }
         return accessPermission;

--- a/core/src/main/java/org/akaza/openclinica/service/pmanage/RandomizationRegistrar.java
+++ b/core/src/main/java/org/akaza/openclinica/service/pmanage/RandomizationRegistrar.java
@@ -25,6 +25,14 @@
  *     plus a null-guard for moduleManager to prevent NPE.
  *   - getCachedRandomizationDTOObject: added null-guard for
  *     seRandomizationDTO to prevent NPE.
+ *   - sendEmail() and randomizeStudy() were not ported: a study is registered
+ *     in the randomization module's own administration, not from LibreClinica,
+ *     so neither had a caller.
+ *   - added a connect timeout next to the existing read timeout, and turned off
+ *     the automatic retries of the underlying HttpClient, so that the Build
+ *     Study page still renders when the module is unreachable. Without the
+ *     second part the default retry handler repeats the request three times
+ *     and the page waits for four connect timeouts instead of one.
  *
  * License selection:
  *   The OpenClinica original was licensed under LGPL v2.1 or later.
@@ -34,27 +42,18 @@
  */
 package org.akaza.openclinica.service.pmanage;
 
-import java.util.Date;
-
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
-
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 
-import org.akaza.openclinica.bean.login.UserAccountBean;
-import org.akaza.openclinica.core.EmailEngine;
 import org.akaza.openclinica.dao.core.CoreResources;
-import org.akaza.openclinica.exception.OpenClinicaSystemException;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 // Modified: CommonsClientHttpRequestFactory (Spring 3 / commons-httpclient 3.x) replaced with
 //           HttpComponentsClientHttpRequestFactory (Spring 5 / httpclient 4.5.7)
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.mail.MailException;
-import org.springframework.mail.javamail.JavaMailSenderImpl;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.web.client.RestTemplate;
 
 public class RandomizationRegistrar {
@@ -65,6 +64,7 @@ public class RandomizationRegistrar {
     public static final String INVALID = "invalid";
     public static final String UNKNOWN = "unknown";
     public static final int RANDOMIZATION_READ_TIMEOUT = 5000;
+    public static final int RANDOMIZATION_CONNECT_TIMEOUT = 5000;
     private static final String CACHE_KEY = "randomizeObject";
     private CacheManager cacheManager;
     private net.sf.ehcache.Cache cache;
@@ -95,9 +95,16 @@ public class RandomizationRegistrar {
         }
         String ocUrl = sysUrlBase + "rest2/openrosa/" + studyOid;
         String randomizationUrl = moduleManager + "/app/rest/oc/se_randomizations?studyoid=" + studyOid + "&instanceurl=" + ocUrl;
-        // Modified: use HttpComponentsClientHttpRequestFactory instead of CommonsClientHttpRequestFactory
-        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+        // Modified: use HttpComponentsClientHttpRequestFactory instead of CommonsClientHttpRequestFactory.
+        // The client is built here rather than taken from the factory default because the default one
+        // retries a failed request three times, so an unreachable module would cost four connect
+        // timeouts. useSystemProperties() keeps the rest of the default client's behaviour.
+        CloseableHttpClient httpClient = HttpClients.custom().useSystemProperties().disableAutomaticRetries().build();
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
         requestFactory.setReadTimeout(RANDOMIZATION_READ_TIMEOUT);
+        // Modified: without a connect timeout an unreachable module blocks the Build Study page
+        // until the operating system gives up on the TCP connection.
+        requestFactory.setConnectTimeout(RANDOMIZATION_CONNECT_TIMEOUT);
         RestTemplate rest = new RestTemplate(requestFactory);
 
         try {
@@ -139,52 +146,5 @@ public class RandomizationRegistrar {
             cache.put(new Element(mapKey, seRandomizationDTO));
         }
         return seRandomizationDTO;
-    }
-
-    public void sendEmail(JavaMailSenderImpl mailSender, UserAccountBean user, String emailSubject, String message) throws OpenClinicaSystemException {
-        logger.info("Sending email...");
-        try {
-            MimeMessage mimeMessage = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
-            helper.setFrom(EmailEngine.getAdminEmail());
-            helper.setTo(user.getEmail());
-            helper.setSubject(emailSubject);
-            helper.setText(message);
-            mailSender.send(mimeMessage);
-            logger.debug("Email sent successfully on {}", new Date());
-        } catch (MailException me) {
-            logger.error("Email could not be sent");
-        } catch (MessagingException me) {
-            logger.error("Email could not be sent");
-        }
-    }
-
-    public String randomizeStudy(String studyOid, String studyName, UserAccountBean userAccount) {
-        String ocUrl = CoreResources.getField("sysURL.base") + "rest2/openrosa/" + studyOid;
-        String randomizationUrl = CoreResources.getField("moduleManager") + "/app/rest/oc/se_randomizations";
-        SeRandomizationDTO seRandomizationDTO = new SeRandomizationDTO();
-        seRandomizationDTO.setStudyOid(studyOid);
-        seRandomizationDTO.setInstanceUrl(ocUrl);
-        seRandomizationDTO.setOcUser_username(userAccount.getName());
-        seRandomizationDTO.setOcUser_name(userAccount.getFirstName());
-        seRandomizationDTO.setOcUser_lastname(userAccount.getLastName());
-        seRandomizationDTO.setOcUser_emailAddress(userAccount.getEmail());
-        seRandomizationDTO.setStudyName(studyName);
-        seRandomizationDTO.setOpenClinicaVersion(CoreResources.getField("OpenClinica.version"));
-
-        // Modified: use HttpComponentsClientHttpRequestFactory
-        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
-        requestFactory.setReadTimeout(RANDOMIZATION_READ_TIMEOUT);
-        RestTemplate rest = new RestTemplate(requestFactory);
-
-        try {
-            SeRandomizationDTO response = rest.postForObject(randomizationUrl, seRandomizationDTO, SeRandomizationDTO.class);
-            if (response != null && response.getStatus() != null)
-                return response.getStatus();
-        } catch (Exception e) {
-            logger.error(e.getMessage());
-            logger.error(ExceptionUtils.getStackTrace(e));
-        }
-        return "";
     }
 }

--- a/docs/development/randomization-module-api.md
+++ b/docs/development/randomization-module-api.md
@@ -26,14 +26,22 @@ to reverse-engineer them from the code.
 
 There are **two distinct bases** and they are not the same host in general:
 
-1. **`moduleManager`** — used for the per-study *configuration* and *study
-   registration* calls (`/app/rest/oc/se_randomizations`).
+1. **`moduleManager`** — used for the per-study *configuration* call
+   (`/app/rest/oc/se_randomizations`).
 2. **`config.url`** — the value returned in the `url` field of the
    configuration response; used for the per-subject *randomisation* calls
    (`/api/...`). These calls use **HTTP Basic authentication** with the
    `username` / `password` from the configuration response.
 
 ## Endpoints
+
+**Studies are registered in the module, not from LibreClinica.** LibreClinica
+never creates or registers a study in the module and calls no registration
+endpoint: which studies may be randomised, by which method, with which arms,
+whether the trial is blinded, and who is allowed to see an allocation are
+decisions that need authorisation and clinical design, and they are made in the
+module's own administration. LibreClinica only reads the resulting
+configuration (endpoint 1) and asks for allocations (endpoints 2 to 4).
 
 ### 1. Get study configuration — `GET {moduleManager}/app/rest/oc/se_randomizations`
 
@@ -55,14 +63,7 @@ Returns a `SeRandomizationDTO` (JSON). Relevant fields LibreClinica reads:
 
 The configuration is cached per study.
 
-### 2. Register a study — `POST {moduleManager}/app/rest/oc/se_randomizations`
-
-Request body (`SeRandomizationDTO`, JSON): `studyOid`, `instanceUrl`,
-`ocUser_username`, `ocUser_name`, `ocUser_lastname`, `ocUser_emailAddress`,
-`studyName`, `openClinicaVersion`. Response: a `SeRandomizationDTO` whose
-`status` reports the registration result.
-
-### 3. Look up an existing allocation — `GET {config.url}/api/randomisation`
+### 2. Look up an existing allocation — `GET {config.url}/api/randomisation`
 
 Auth: Basic. Query parameter:
 
@@ -75,7 +76,7 @@ If the subject is already randomised, return a JSON object containing a
 `code`-bearing JSON object (e.g. `404`); LibreClinica then proceeds to
 register the site and randomise.
 
-### 4. Register / update a site — `POST {config.url}/api/sites`
+### 3. Register / update a site — `POST {config.url}/api/sites`
 
 Auth: Basic. Content type: `application/x-www-form-urlencoded`.
 
@@ -85,7 +86,7 @@ Auth: Basic. Content type: `application/x-www-form-urlencoded`.
 | `name` | Study name |
 | `timezone` | Server default timezone (IANA id) |
 
-### 5. Randomise a subject — `POST {config.url}/api/randomise`
+### 4. Randomise a subject — `POST {config.url}/api/randomise`
 
 Auth: Basic. Content type: `application/x-www-form-urlencoded`.
 

--- a/web/src/main/java/org/akaza/openclinica/controller/StudyModuleController.java
+++ b/web/src/main/java/org/akaza/openclinica/controller/StudyModuleController.java
@@ -42,6 +42,8 @@ import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
 import org.akaza.openclinica.service.pmanage.Authorization;
 import org.akaza.openclinica.service.pmanage.ParticipantPortalRegistrar;
+import org.akaza.openclinica.service.pmanage.RandomizationRegistrar;
+import org.akaza.openclinica.service.pmanage.SeRandomizationDTO;
 import org.akaza.openclinica.service.rule.RuleSetServiceInterface;
 import org.akaza.openclinica.view.StudyInfoPanel;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -91,6 +93,13 @@ public class StudyModuleController {
     private UserAccountDAO userDao;
     protected final Logger logger = LoggerFactory.getLogger(getClass().getName());
     public static final String REG_MESSAGE = "regMessages";
+    /**
+     * Randomization status reported to studymodule.jsp when the external module could not be
+     * reached, or does not know this study. It is deliberately different from an empty status,
+     * which the page renders as "Disabled" - a study that is switched off and a module that is
+     * unreachable need to be distinguishable.
+     */
+    public static final String RANDOMIZATION_STATUS_NOT_FOUND = "NOTFOUND";
     public static ResourceBundle respage;
     @Autowired
     CoreResources coreResources;
@@ -382,7 +391,37 @@ public class StudyModuleController {
 
             String randomizationStatus = "";
             URL randomizeUrl = null;
-            
+            // Read the status and the URL the external module reports for this study. The Build
+            // Study page needs them to decide whether randomization can be enabled: without a
+            // status it always renders "Disabled" and the Enable action that writes the
+            // "randomization" study parameter is never offered, so the RANDOMIZE rule action can
+            // never pass its activation gate.
+            // moduleManager is known to be configured here (see the enclosing if), and when it is
+            // not configured this whole block - and the randomization row of the page - is skipped.
+            // A null response, or one without a status, therefore means the module could not be
+            // reached or does not know this study; that is reported as
+            // RANDOMIZATION_STATUS_NOT_FOUND rather than left empty.
+            try {
+                RandomizationRegistrar randomizationRegistrar = new RandomizationRegistrar();
+                SeRandomizationDTO randomization = randomizationRegistrar.getCachedRandomizationDTOObject(currentStudy.getOid(), true);
+                if (randomization != null && randomization.getStatus() != null) {
+                    randomizationStatus = randomization.getStatus();
+                    if (randomization.getUrl() != null) {
+                        randomizeUrl = new URL(randomization.getUrl());
+                    }
+                }
+            } catch (MalformedURLException e) {
+                logger.error("Randomization module reported a malformed URL for study {}: {}", currentStudy.getOid(), e.getMessage());
+                logger.error(ExceptionUtils.getStackTrace(e));
+            } catch (Exception e) {
+                logger.error("Could not read the randomization configuration of study {} from {}: {}", currentStudy.getOid(), moduleManager,
+                        e.getMessage());
+                logger.error(ExceptionUtils.getStackTrace(e));
+            }
+            if (randomizationStatus.equals("")) {
+                randomizationStatus = RANDOMIZATION_STATUS_NOT_FOUND;
+            }
+
             map.addAttribute("randomizeURL", randomizeUrl);
             map.addAttribute("randomizationOCStatus", randomizationOCStatus);
             map.addAttribute("randomizationStatus", randomizationStatus);

--- a/web/src/main/webapp/WEB-INF/jsp/studymodule.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/studymodule.jsp
@@ -48,36 +48,6 @@
     }
 </script>
 
- <c:if test="${moduleManager!= '' && moduleManager!= null}">
-
-      <script type="text/javascript">
-        jQuery(document).ready(function() {
-            jQuery('#requestRandomizationAccess').click(function() {
-                jQuery.blockUI({ message: jQuery('#requestRandomizationForm'), css:{left: "300px", top:"10px" } });
-            });
-
-            jQuery('#cancelRandomizationAccessRequest').click(function() {
-                jQuery.unblockUI();
-                $('#randomizationWarnings').empty();
-            });
-            // If there are warnings, we failed in a previous submission and should display the warnings on the popup window.
-            var warnings = "${regMessages}";
-            if (warnings.length > 0) {
-            	jQuery.blockUI({ message: jQuery('#requestRandomizationForm'), css:{left: "300px", top:"10px" } });
-            }
-        });
-
-        // Hide the popup window if the escape key is pressed
-        jQuery(document).keyup(function(keyPressed) {
-            if(keyPressed.keyCode === 27) {
-                $('#randomizationWarnings').empty();
-                jQuery.unblockUI();
-            }
-        });
-    </script>
-</c:if>
-
-
 <c:if test="${portalURL!= '' && portalURL!= null}">
     <script type="text/javascript">
         jQuery(document).ready(function() {
@@ -577,14 +547,17 @@
           </c:if>
 
          <c:if test="${moduleManager!= '' && moduleManager!= null}">
+          <%-- StudyModuleController reports NOTFOUND when the randomization module could not be reached
+               or does not know this study; that must not look like a study that is switched off. --%>
+          <c:set var="randomizationModuleFound" value="${!empty randomizationStatus && randomizationStatus != 'NOTFOUND'}"/>
           <tbody>
               <tr>
                   <td>&nbsp;</td>
                   <td><fmt:message key="randomization" bundle="${resword}"/></td>
                   <td>
                       <c:choose>
+                          <c:when test="${!randomizationModuleFound}"><span id="randomizationStatus"><fmt:message key="randomization_status_notfound" bundle="${resword}"/></span></c:when>
                           <c:when test="${randomizationOCStatus == 'disabled'}"><span id="randomizationStatus" class="randomization-inactive-status"><fmt:message key="randomization_status_deactivated" bundle="${resword}"/></span></c:when>
-                          <c:when test="${empty randomizationStatus}"><span id="randomizationStatus" class="randomization-inactive-status"><fmt:message key="randomization_status_deactivated" bundle="${resword}"/></span></c:when>
                           <c:when test="${randomizationStatus == 'PENDING'}"><span id="randomizationStatus"><fmt:message key="randomization_status_pending" bundle="${resword}"/></span></c:when>
                           <c:when test="${randomizationStatus == 'ACTIVE'}"><span id="randomizationStatus" class="randomization-active-status"><fmt:message key="randomization_status_active" bundle="${resword}"/></span></c:when>
                           <c:when test="${randomizationStatus == 'INACTIVE'}"><span id="randomizationStatus" class="randomization-inactive-status"><fmt:message key="randomization_status_inactive" bundle="${resword}"/></span></c:when>
@@ -592,21 +565,22 @@
                   </td>
                   <td>
                     <span id="randomizeURL">
-                              <a href="<c:url value="${randomizeURL}"/>" target="_blank">${randomizeURL}</a>
+                          <c:choose>
+                              <c:when test="${!empty randomizeURL}"><a href="<c:url value="${randomizeURL}"/>" target="_blank">${randomizeURL}</a></c:when>
+                              <c:otherwise>&nbsp;</c:otherwise>
+                          </c:choose>
                     </span>
                   </td>
                   <td>
                       <c:url var="reactivateRandomization" value="studymodule/${currentStudy.oid}/reactivaterandomization"/>
                       <c:url var="deactivateRandomization" value="studymodule/${currentStudy.oid}/deactivaterandomization"/>
                       <c:choose>
-                          <c:when test="${randomizationOCStatus == 'disabled' && !empty randomizationStatus}">
+                          <c:when test="${randomizationOCStatus == 'disabled' && randomizationModuleFound}">
                               <a href="${reactivateRandomization}" id="reactivateRandomizationAccess"><img src="../images/create_new.gif" border="0" alt="<fmt:message key="enable" bundle="${resword}"/>" title="<fmt:message key="enable" bundle="${resword}"/>"/></a>
                           </c:when>
                           <c:when test="${randomizationOCStatus == 'disabled'}">
-                              <a href="javascript:;" id="requestRandomizationAccess"><img src="../images/create_new.gif" border="0" alt="<fmt:message key="enable" bundle="${resword}"/>" title="<fmt:message key="enable" bundle="${resword}"/>"/></a>
-                          </c:when>
-                          <c:when test="${randomizationOCStatus == 'enabled' && empty randomizationStatus}">
-                              <a href="javascript:;" id="requestRandomizationAccess" ><img src="../images/create_new.gif" border="0" alt="<fmt:message key="enable" bundle="${resword}"/>" title="<fmt:message key="enable" bundle="${resword}"/>"/></a>
+                              <%-- the module does not know this study, so there is nothing to enable --%>
+                              &nbsp;
                           </c:when>
                           <c:otherwise>
                               <a href="${deactivateRandomization}" id="removeRandomizeAccess"><img src="../images/bt_Remove.gif" border="0" alt="<fmt:message key="disable" bundle="${resword}"/>" title="<fmt:message key="disable" bundle="${resword}"/>"/></a>
@@ -669,20 +643,6 @@
             </c:if>
             <input type="submit" id="submitParticipateAccessRequest" class="button_medium" value="Request Access"/>
             <input type="button" id="cancelParticipateAccessRequest" class="button" value="Cancel"/>
-        </form>
-    </div>
-</c:if>
-
- <c:if test="${moduleManager!= '' && moduleManager!= null}">
-    <div id="requestRandomizationForm" class="randomization-registration-div">
-        <form action="studymodule/${currentStudy.oid}/randomize" method="post">
-            <h1>
-                <fmt:message key="randomization_reg_title" bundle="${resword}"/>
-            </h1>
-            <p class="randomization-text"><fmt:message key="randomization_reg_instructions_part1" bundle="${resword}"/></p>
-            <br>
-            <input type="submit" id="submitRandomizationAccessRequest" class="button_medium" value="Request Access"/>
-            <input type="button" id="cancelRandomizationAccessRequest" class="button" value="Cancel"/>
         </form>
     </div>
 </c:if>


### PR DESCRIPTION
## Summary

Follow-up to #452, against the same `lc-randomize` feature branch.

As merged, **randomization cannot be switched on**. The Build Study page always
renders *Disabled*, the action that writes the `randomization` study parameter is
never offered, and `RandomizeActionProcessor.mayProceed()` therefore never passes
its first condition — a CRF `Save` never triggers an allocation. This was reported
in [#452 (comment)](https://github.com/reliatec-gmbh/LibreClinica/pull/452#issuecomment-5176807240).

This PR restores that path, makes an unreachable module distinguishable from a
disabled one, fixes a **second, independent** reason allocations never fired (any
non-English UI locale), and removes dead code and an incorrect API statement that
#452 introduced.

No resource bundle is touched, so this is independent of #462 and the two can be
merged in either order.

## What was broken

**1. The Enable action was unreachable.** `studymodule.jsp` renders the link to
`studymodule/{oid}/reactivaterandomization` only when `randomizationStatus` is
non-empty, and that attribute is filled by `StudyModuleController.handleMainPage`.
#75 removed the lookup that fills it and #452 did not restore it, so it was always
`""`. The page fell through to the other Enable branch, which opened the
OpenClinica *request access* dialog whose POST target `studymodule/{oid}/randomize`
was also removed in #75 — a 404.

`study_parameter_value.randomization` is written **only** by `reactivateRandomization`
/ `deactivateRandomization` in that controller (no other writer exists under
`web/src/main/java`). With the link gone the parameter could never become `enabled`,
and `mayProceed()`'s first condition could never hold.

**2. An unreachable module looked like a disabled one.** With no status the page
rendered `randomization_status_deactivated` ("Disabled") — the same as a study that
was deliberately switched off. An administrator had no way to tell "this study is
off" from "the module cannot be reached".

**3. No allocation on a non-English UI locale** — independent of 1 and 2, and
inherited from the OpenClinica original. `mayProceed()` compared
`study.getStatus().getName()` with the English literal `"available"`. `Term.getName()`
resolves the term through the `terms` bundle, i.e. it returns the *translated* name,
so with `terms_ja.properties` (`available=有効`) present the gate is always false in a
Japanese session and the action silently does nothing — no exception, no warning.
The same comparison is in `463e312ad^` (the pre-#75 code), so #452 ported it verbatim;
it only became reachable once a translated `terms` bundle existed, which is what the
Japanese bundle (#448) added.

## Changes (5 files, +99 / −130)

| File | Change |
|---|---|
| `web/.../controller/StudyModuleController.java` | `handleMainPage` reads the study's status and URL from the module again and puts them on the model. `catch` is split into `MalformedURLException` and everything else so the log distinguishes a bad URL from an unreachable module. When nothing usable comes back, the status is reported as `NOTFOUND` instead of being left empty. |
| `web/.../jsp/studymodule.jsp` | `randomizationModuleFound` is derived once and the *not found* branch is evaluated first, so an unreachable module shows **Not Found** rather than *Disabled*. Enable is offered only when the module is reachable and the study parameter is `disabled`; Disable stays available otherwise, so a study can still be switched off if the module goes away. The dead request-access form, its JavaScript and the last reference to `studymodule/{oid}/randomize` are removed. The URL cell no longer renders an empty `<a href="">`. |
| `core/.../service/pmanage/RandomizationRegistrar.java` | `randomizeStudy()` and `sendEmail()` removed (see below). A connect timeout is added next to the existing read timeout, and the underlying `HttpClient`'s automatic retries are disabled — without that the default handler repeats the request three times and the Build Study page waits for four connect timeouts instead of one. |
| `core/.../domain/rule/action/RandomizeActionProcessor.java` | The two status checks compare `Status.AVAILABLE` with the status itself instead of comparing the localized `Term.getName()` with an English literal (2 lines). |
| `docs/development/randomization-module-api.md` | "Register a study" removed; the endpoint list is renumbered and a paragraph states that studies are registered in the module, not from LibreClinica. |

The *Not Found* label reuses `randomization_status_notfound`, which is already
defined in `words.properties` and had no reference. **No `.properties` file is
modified** — `git diff` over `*.properties` is empty, as it is over `pom.xml`, `ws/`,
`ViewStudyServlet` and `SystemController`.

Resulting status cell:

| Module | Study parameter | Status cell | Action |
|---|---|---|---|
| unreachable / unknown study | any | Not Found | — |
| reachable | `disabled` | Disabled | Enable |
| reachable | `enabled` | Pending / Active / Inactive | Disable |

## Why the OpenClinica "request access" flow is not brought back

The removed dialog POSTed to `studymodule/{oid}/randomize`, which called
`randomizeStudy()` to register the study in the module. Registering a study decides
which randomisation method applies, which arms exist, whether the trial is blinded
and who may see an allocation — decisions that need authorisation and clinical design
and are made in the module's own administration, together with the accounts that go
with them. A module can also legitimately refuse to accept registration requests at
all. LibreClinica has no way to complete that, so the honest interface is the one this
PR leaves in place: LibreClinica reads the configuration and asks for allocations; the
study is registered on the module side. This is deliberately asymmetric with
*participate*, which does own its registration.

That is why `randomizeStudy()` and `sendEmail()` (the notification that went with the
request) are removed rather than wired up, and why the registration endpoint is gone
from the API document.

## Verification

Isolated instance (separate port, separate database — production untouched), the
production browser flow, and a **real external randomization service over HTTPS**, not
a mock. A new study was created for this, so the study parameter started from its
default (`StudyParameterConfig` writes `disabled`).

- `mvn -B -DskipTests clean package` — **BUILD SUCCESS** for all 6 modules, no `[ERROR]`.
- **Enabled through the UI only.** The new study had no `study_parameter_value` row;
  the page showed *Disabled* with the Enable icon (which is rendered only when the
  module reported a status), the click created `(randomization, enabled)`, and the page
  then showed *Active* with the Disable icon. **No SQL was used to enable it** — the only
  statements issued during the check were `SELECT`s.
- **Allocation fires over the wire.** 7 subjects, **one at a time**; every one produced a
  `POST /api/randomise` answered **HTTP 200** by the external service. Its operation log
  and its web access log line up **1:1 by timestamp** with the LibreClinica log, and the
  allocation code stored in `item_data` matches the code the service recorded for all
  **7/7** subjects (non-empty 7, unique 7, subjects = allocations). No allocation value was
  written by SQL.
- **Module unreachable** (endpoint that answers 404): Build Study returns **HTTP 200**, the
  cell shows **Not Found**, no Enable icon, no `/randomize` link, and the page renders in
  **2.96 / 3.08 / 3.10 s** — it took 12.1–13.5 s before the automatic retries were disabled.
  Saving a CRF in that state allocates nothing, logs
  `Failed to retrieve randomization DTO for study: ...`, and leaves the application healthy.
- **`moduleManager` unset**: startup logs `Module Manager URL NOT Defined in datainfo`, Build
  Study returns HTTP 200 in 941 ms and the randomization row is simply not rendered — #39
  is not reintroduced.
- **Locale.** With the same data, study and instance, one subject did **not** randomise in a
  Japanese session before the fix and **did** after it; the remaining subjects were all
  randomised from Japanese sessions. A control subject randomised from an English session
  before the fix, so the only difference was the locale.
- The service was configured for dynamic allocation (minimisation); recomputing the
  imbalance scores independently of the service shows all **7/7** allocations went to an arm
  with the minimal score, including two subjects for which the minimum was unique.
- `RandomizationRegistrar` has no public member left without a caller (checked
  mechanically, before and after).

## Corrections to #452

- "**activation is only through the opt-in RANDOMIZE rule action**" is not accurate. The rule
  action is opt-in, but it is gated on the `randomization` study parameter, which is set from
  the Build Study page — and it was exactly that path that was missing. The safety claim about
  #39 still holds (an unset `moduleManager` performs no HTTP call and the page renders), and it
  is re-verified above.
- "`core/pom.xml` declares `jackson-databind` and **`httpcore`** explicitly" is stale: the
  explicit `httpcore` dependency was dropped in `fa709c6f` when the in-code trust of
  self-signed certificates was removed during review. `jackson-databind` is still declared.
  Nothing is added here either — `httpclient` is already declared for all modules in the
  parent `pom.xml`.
- `randomizeStudy()` and `sendEmail()` were ported **without any caller**, and the API document
  listed the corresponding registration endpoint as one an external module must implement.
  Both are corrected here.

## Deliberately out of scope

- **The same localized-name comparison exists elsewhere.** As of this branch's head
  (`e266e2435`), **156 comparisons** put the result of `Term.getName()` — a name resolved through
  the `terms` bundle, i.e. a *translated* string — on one side and an English literal or an
  external input on the other: **114 in JSPs/tag files and 42 in Java** (25 Java classes, 23 JSP
  and tag files). All of them change behaviour as soon as a translated `terms` bundle is present:
  unlock and restore buttons disappear, a Study Director loses action icons, removed studies and
  subjects keep showing their links, and **twelve server-side classes stop guarding on "removed"** —
  among them `DataEntryServlet`, `CreateNewStudyEventServlet`, `UpdateStudyEventServlet`,
  `RestoreStudyEventServlet`, `RestoreEventCRFServlet`, `SignStudySubjectServlet`,
  `ViewStudySubjectServlet` and `RestoreSiteServlet`. Two groups are worth calling out because a
  line-by-line reading of the sources is what surfaced them: **15 Java comparisons save the
  translated name in a local variable first** and compare on a later line — these are the
  `mayProceed()` guards of the *participate* REST and form controllers (`AccountController`,
  `AnonymousFormControllerV2`, `EditFormController`, `OdmController`, `OdmStudySubjectController`,
  `UserInfoController`, `OpenRosaServices`), which then refuse access. What decides the locale
  there is not the session: every one of them except `OpenRosaServices` calls
  `updateLocale(new Locale("en_US"))` at the top of the handler, and since that is an invalid
  language tag and no `_en` bundle exists, the bundle comes from the JVM default locale — so on a
  server whose default locale is Japanese they refuse every user, whatever language the session is
  in. `OpenRosaServices` forces no locale and follows the request's `Accept-Language` instead.
  The other group is **8 comparisons of an external input against a translated name**, namely the
  `EventCRFStatus` of an imported ODM `<FormData>` and the `user_type` of the user REST API.
  Most server-side checks are unaffected because they compare the status itself rather than its
  name (`== Status.DELETED`, `isDeleted()` — 127 places in `web`), and the correct idiom — testing
  against a `<fmt:message>` variable — is already used in 92 JSP comparisons; it was simply never
  applied consistently. Note that this is **not limited to a Japanese UI**: if the JVM default
  locale is `ja_JP`, the `terms` bundle resolves to `terms_ja` even in an English session.
  The count is a census taken at that commit and reproducible from it, one comparison operation per
  entry; it excludes 37 occurrences that sit inside JSP comments and are never compiled, and it does
  not include indirect flows, where a translated name is stored and used later (for example
  `ViewNotesServlet` keys a map by `DiscrepancyNoteType.getName()`, both `MetaDataReportBean` and
  `ExtractBean` write `getStatus().getName()` into exported data, and `UserProcessor` puts
  `Role.getName()` into a `StudyUserRoleId` — 70 such flows in Java).
  Only the randomization gate is fixed here, because it is the one that makes this feature do
  nothing at all. The rest would be better looked at on its own, so that it can be judged
  separately from this fix.
- **`randomization_reg_title` and `randomization_reg_instructions_part1`** lose their last
  reference with the dialog. They stay defined: this PR touches no resource bundle, so it stays
  independent of #462. They belong to a group of OpenClinica-branded strings, including one that
  names `sales@openclinica.com`, which would be better removed together once #462 is merged.
- `RandomizationRegistrar`'s four public constants (`AVAILABLE`, `UNAVAILABLE`, `INVALID`,
  `UNKNOWN`) have no reference anywhere; they are left alone since only unreachable methods were
  in scope.
- `RandomizeService.RANDOMIZATION_READ_TIMEOUT` is declared but never applied — its request
  factory is the plain default — so the three `/api/...` calls it makes run without a timeout.
  `RandomizeService` is not among the files this PR changes; it would be worth a look.

## Licensing

The two modified `core` classes keep their four-party header (Akaza / OpenClinica /
LibreClinica 2020 - 2026 / UMIN 2026, LGPL v3 selected under the original "v2.1 or later",
port author Yoshiteru Chiba, copyright assigned to UMIN); the change notes at the top of each
file are extended to describe what changed here. `StudyModuleController.java`,
`studymodule.jsp` and the API document are existing LibreClinica files and keep their headers
unchanged.
