### PR TITLE
First working implementation of LCTable-based `listNotes` table.

### DIFF
--- a/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesFilterCriteria.java
+++ b/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesFilterCriteria.java
@@ -5,7 +5,7 @@
  * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
- * copyright (C) 2020 - 2024 LibreClinica
+ * copyright (C) 2020 - 2026 LibreClinica
  */
 package org.akaza.openclinica.service.managestudy;
 
@@ -164,6 +164,20 @@ public class ViewNotesFilterCriteria {
 
     public Integer getPageSize() {
         return pageSize;
+    }
+
+    /**
+     * Sets pagination parameters (1-based page number and page size) on this filter criteria.
+     * Needed when using the {@link #buildFilterCriteria(Map, String, Map, Map)} builder, which -- unlike the
+     * {@code Limit}-based overload above -- has no jmesa {@code RowSelect} to derive pagination from
+     * (used by the LCTable-based "listNotes" table).
+     *
+     * @return {@code this}, for fluent chaining
+     */
+    public ViewNotesFilterCriteria withPagination(int pageNumber, int pageSize) {
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
+        return this;
     }
 
 

--- a/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesSortCriteria.java
+++ b/core/src/main/java/org/akaza/openclinica/service/managestudy/ViewNotesSortCriteria.java
@@ -5,7 +5,7 @@
  * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
- * copyright (C) 2020 - 2024 LibreClinica
+ * copyright (C) 2020 - 2026 LibreClinica
  */
 package org.akaza.openclinica.service.managestudy;
 
@@ -52,6 +52,22 @@ public class ViewNotesSortCriteria {
         for (Sort sort : sortSet.getSorts()) {
             String sortField = SORT_BY_TABLE_COLUMN.get(sort.getProperty());
             criteria.getSorters().put(sortField, sort.getOrder().name());
+        }
+        return criteria;
+    }
+
+    /**
+     * Builds sort criteria from a single (column, direction) pair, as used by {@code LCTableParams}
+     * (sortProp/sortDir) for the LCTable-based "listNotes" table -- as opposed to the multi-column jmesa
+     * {@code SortSet}/{@code List<Pair<String,String>>} overloads above.
+     */
+    public static ViewNotesSortCriteria buildFilterCriteria(String sortProp, String sortDir) {
+        ViewNotesSortCriteria criteria = new ViewNotesSortCriteria();
+        if (sortProp != null && !sortProp.isEmpty()) {
+            String sortField = SORT_BY_TABLE_COLUMN.get(sortProp);
+            if (sortField != null) {
+                criteria.getSorters().put(sortField, (sortDir == null || sortDir.isEmpty()) ? "asc" : sortDir);
+            }
         }
         return criteria;
     }

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ViewNotesServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ViewNotesServlet.java
@@ -5,7 +5,7 @@
  * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
- * copyright (C) 2020 - 2024 LibreClinica
+ * copyright (C) 2020 - 2026 LibreClinica
  */
 package org.akaza.openclinica.control.managestudy;
 
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.akaza.openclinica.bean.core.DiscrepancyNoteType;
@@ -23,6 +24,7 @@ import org.akaza.openclinica.bean.managestudy.DiscrepancyNoteBean;
 import org.akaza.openclinica.bean.managestudy.StudySubjectBean;
 import org.akaza.openclinica.control.core.SecureController;
 import org.akaza.openclinica.control.form.FormProcessor;
+import org.akaza.openclinica.control.submit.ListNotesTable;
 import org.akaza.openclinica.control.submit.ListNotesTableFactory;
 import org.akaza.openclinica.control.submit.SubmitDataServlet;
 import org.akaza.openclinica.dao.admin.CRFDAO;
@@ -38,6 +40,7 @@ import org.akaza.openclinica.dao.submit.EventCRFDAO;
 import org.akaza.openclinica.dao.submit.ItemDAO;
 import org.akaza.openclinica.dao.submit.ItemDataDAO;
 import org.akaza.openclinica.dao.submit.SubjectDAO;
+import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.service.DiscrepancyNoteUtil;
 import org.akaza.openclinica.service.DiscrepancyNotesSummary;
 import org.akaza.openclinica.service.managestudy.ViewNotesService;
@@ -73,6 +76,7 @@ public class ViewNotesServlet extends SecureController {
      */
     @Override
     protected void processRequest() throws Exception {
+        Locale locale = LocaleResolver.getLocale(request);
         String module = request.getParameter("module");
         String moduleStr = "manage";
         if (module != null && module.trim().length() > 0) {
@@ -172,59 +176,105 @@ public class ViewNotesServlet extends SecureController {
 
 
 
-        ListNotesTableFactory factory = new ListNotesTableFactory(showMoreLink);
-        factory.setSubjectDao(sdao);
-        factory.setStudySubjectDao(subdao);
-        factory.setUserAccountDao(uadao);
-        factory.setStudyDao(studyDao);
-        factory.setCurrentStudy(currentStudy);
-        factory.setDiscrepancyNoteDao(dndao);
-        factory.setCrfDao(crfDao);
-        factory.setCrfVersionDao(crfVersionDao);
-        factory.setStudyEventDao(studyEventDao);
-        factory.setStudyEventDefinitionDao(studyEventDefinitionDao);
-        factory.setEventDefinitionCRFDao(eventDefinitionCRFDao);
-        factory.setItemDao(itemDao);
-        factory.setItemDataDao(itemDataDao);
-        factory.setEventCRFDao(eventCRFDao);
-        factory.setModule(moduleStr);
-        factory.setDiscNoteType(discNoteType);
-        factory.setResolutionStatus(resolutionStatus);
-        factory.setViewNotesService(resolveViewNotesService());
-        //factory.setResolutionStatusIds(resolutionStatusIds);
-        TableFacade tf = factory.createTable(request, response);
-
-        Map<String, Map<String, String>> stats = generateDiscrepancyNotesSummary(factory.getNotesSummary());
-        Map<String,String> totalMap = generateDiscrepancyNotesTotal(stats);
-
-        int grandTotal = 0;
-        for (String typeName: totalMap.keySet()) {
-            String total = totalMap.get(typeName);
-            grandTotal = total.equals("--") ? grandTotal + 0 : grandTotal + Integer.parseInt(total);
-        }
-        request.setAttribute("summaryMap", stats);
-
-        tf.setTotalRows(grandTotal);
-        String viewNotesHtml = tf.render();
-
-        request.setAttribute("viewNotesHtml", viewNotesHtml);
         String viewNotesURL = this.getPageURL();
         session.setAttribute("viewNotesURL", viewNotesURL);
         String viewNotesPageFileName = this.getPageServletFileName();
         session.setAttribute("viewNotesPageFileName", viewNotesPageFileName);
 
-        request.setAttribute("mapKeys", ResolutionStatus.getMembers());
-        request.setAttribute("typeNames", DiscrepancyNoteUtil.getTypeNames());
-        request.setAttribute("typeKeys", totalMap);
-        request.setAttribute("grandTotal", grandTotal);
+        String lcTableRendering = System.getenv("LC_TABLE_RENDERING");
+        // Use JMesa rendering only when LC_TABLE_RENDERING is explicitly set to "jmesa"
+        if (lcTableRendering != null && lcTableRendering.equalsIgnoreCase("jmesa")) {
+            // Legacy JMesa rendering path: unchanged behaviour (render and forward)
+            request.setAttribute("tableRenderingMode", "jmesa");
 
-        if ("yes".equalsIgnoreCase(fp.getString(PRINT))) {
-        	List<DiscrepancyNoteBean> allNotes = factory.findAllNotes(tf);
-            request.setAttribute("allNotes", allNotes);
-            forwardPage(Page.VIEW_DISCREPANCY_NOTES_IN_STUDY_PRINT);
+            ListNotesTableFactory factory = new ListNotesTableFactory(showMoreLink);
+            factory.setSubjectDao(sdao);
+            factory.setStudySubjectDao(subdao);
+            factory.setUserAccountDao(uadao);
+            factory.setStudyDao(studyDao);
+            factory.setCurrentStudy(currentStudy);
+            factory.setDiscrepancyNoteDao(dndao);
+            factory.setCrfDao(crfDao);
+            factory.setCrfVersionDao(crfVersionDao);
+            factory.setStudyEventDao(studyEventDao);
+            factory.setStudyEventDefinitionDao(studyEventDefinitionDao);
+            factory.setEventDefinitionCRFDao(eventDefinitionCRFDao);
+            factory.setItemDao(itemDao);
+            factory.setItemDataDao(itemDataDao);
+            factory.setEventCRFDao(eventCRFDao);
+            factory.setModule(moduleStr);
+            factory.setDiscNoteType(discNoteType);
+            factory.setResolutionStatus(resolutionStatus);
+            factory.setViewNotesService(resolveViewNotesService());
+            TableFacade tf = factory.createTable(request, response);
+
+            Map<String, Map<String, String>> stats = generateDiscrepancyNotesSummary(factory.getNotesSummary());
+            Map<String, String> totalMap = generateDiscrepancyNotesTotal(stats);
+            int grandTotal = computeGrandTotal(totalMap);
+            request.setAttribute("summaryMap", stats);
+
+            tf.setTotalRows(grandTotal);
+            String viewNotesHtml = tf.render();
+            request.setAttribute("viewNotesHtml", viewNotesHtml);
+
+            request.setAttribute("mapKeys", ResolutionStatus.getMembers());
+            request.setAttribute("typeNames", DiscrepancyNoteUtil.getTypeNames());
+            request.setAttribute("typeKeys", totalMap);
+            request.setAttribute("grandTotal", grandTotal);
+
+            if ("yes".equalsIgnoreCase(fp.getString(PRINT))) {
+                List<DiscrepancyNoteBean> allNotes = factory.findAllNotes(tf);
+                request.setAttribute("allNotes", allNotes);
+                forwardPage(Page.VIEW_DISCREPANCY_NOTES_IN_STUDY_PRINT);
+            } else {
+                forwardPage(Page.VIEW_DISCREPANCY_NOTES_IN_STUDY);
+            }
         } else {
-            forwardPage(Page.VIEW_DISCREPANCY_NOTES_IN_STUDY);
+            // HtmlFlow rendering path: supports HTMX partials (panel vs full page)
+            request.setAttribute("tableRenderingMode", "htmlflow");
+
+            ListNotesTable table = new ListNotesTable(resolveViewNotesService(), currentStudy, discNoteType, resolutionStatus, moduleStr, locale);
+            String viewNotesHtml = table.render(request);
+
+            Map<String, Map<String, String>> stats = generateDiscrepancyNotesSummary(table.getNotesSummary());
+            Map<String, String> totalMap = generateDiscrepancyNotesTotal(stats);
+            int grandTotal = computeGrandTotal(totalMap);
+            request.setAttribute("summaryMap", stats);
+
+            request.setAttribute("mapKeys", ResolutionStatus.getMembers());
+            request.setAttribute("typeNames", DiscrepancyNoteUtil.getTypeNames());
+            request.setAttribute("typeKeys", totalMap);
+            request.setAttribute("grandTotal", grandTotal);
+
+            if ("yes".equalsIgnoreCase(fp.getString(PRINT))) {
+                List<DiscrepancyNoteBean> allNotes = table.findAllNotes(request);
+                request.setAttribute("allNotes", allNotes);
+                forwardPage(Page.VIEW_DISCREPANCY_NOTES_IN_STUDY_PRINT);
+            } else {
+                // HTMX partial handling
+                response.addHeader("Vary", "HX-Request");
+                String hxReq = request.getHeader("HX-Request");
+                if (hxReq != null) {
+                    // HTMX request: only return the table HTML fragment
+                    response.setContentType("text/html;charset=UTF-8");
+                    response.getWriter().write(viewNotesHtml);
+                    response.getWriter().flush();
+                } else {
+                    // Non-HTMX request: embed into JSP and forward
+                    request.setAttribute("viewNotesHtml", viewNotesHtml);
+                    forwardPage(Page.VIEW_DISCREPANCY_NOTES_IN_STUDY);
+                }
+            }
         }
+    }
+
+    private int computeGrandTotal(Map<String, String> totalMap) {
+        int grandTotal = 0;
+        for (String typeName : totalMap.keySet()) {
+            String total = totalMap.get(typeName);
+            grandTotal = total.equals("--") ? grandTotal + 0 : grandTotal + Integer.parseInt(total);
+        }
+        return grandTotal;
     }
 
     /**

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTable.java
@@ -1,0 +1,442 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+
+ * For details see: https://libreclinica.org/license
+ * copyright (C) 2026 LibreClinica
+ */
+package org.akaza.openclinica.control.submit;
+
+import org.akaza.openclinica.bean.core.DiscrepancyNoteType;
+import org.akaza.openclinica.bean.core.ResolutionStatus;
+import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.bean.managestudy.DiscrepancyNoteBean;
+import org.akaza.openclinica.bean.managestudy.StudyBean;
+import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+import org.akaza.openclinica.lctable.*;
+import org.akaza.openclinica.service.DiscrepancyNotesSummary;
+import org.akaza.openclinica.service.managestudy.ViewNotesFilterCriteria;
+import org.akaza.openclinica.service.managestudy.ViewNotesService;
+import org.akaza.openclinica.service.managestudy.ViewNotesSortCriteria;
+import org.xmlet.htmlapifaster.Div;
+import org.xmlet.htmlapifaster.Td;
+
+import static org.akaza.openclinica.lctable.LCTableColumnDef.*;
+import static org.akaza.openclinica.lctable.LCTableFilterDef.*;
+import static org.akaza.openclinica.lctable.SafeUrl.url;
+
+import javax.servlet.http.HttpServletRequest;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.function.BiConsumer;
+
+/**
+ * LCTable-based "listNotes" table ("Notes and Discrepancies" page, reachable via {@code ViewNotes}).
+ *
+ * <p>Columns are fixed, but a new instance is created per request to handle request-scoped
+ * variables ({@code discNoteType}, {@code resolutionStatus}, {@code module}) used in toolbar links.
+ * Row fetching delegates to {@link ViewNotesService}, filtering and sorting to {@link ViewNotesFilterCriteria} and
+ * {@link ViewNotesSortCriteria}.
+ *
+ * <p>Preserves legacy behaviour for parity: exact-integer matches for {@code age}/{@code days} filters,
+ * unmodified "numberOfNotes" counts, and omission of the per-row download link (legacy dead code).
+ * Fixes a legacy bug: compares entity type by value instead of reference.
+ */
+public class ListNotesTable {
+
+    private final ViewNotesService viewNotesService;
+    private final StudyBean currentStudy;
+    private final Integer discNoteType;         // top-level "type" request param -- NOT a column filter (see class javadoc)
+    private final Integer resolutionStatus;     // top-level "resolutionStatus" request param -- NOT a column filter
+    private final String module;
+
+    private final ResourceBundle resword;
+    private final ResourceBundle resformat;
+
+    private final List<NoteFilterOption> discNoteTypeFilterOptions;
+    private final List<NoteFilterOption> resolutionStatusFilterOptions;
+    private final Map<String, String> discNoteTypeDecoder;
+    private final Map<String, String> resolutionStatusDecoder;
+
+    private final LCTable<DiscrepancyNoteBean> table;
+
+    /** Set during {@link #fetchData} and read by {@link #getNotesSummary()} (single-threaded per-request use). */
+    private DiscrepancyNotesSummary notesSummary;
+
+    public ListNotesTable(
+        ViewNotesService viewNotesService, StudyBean currentStudy, Integer discNoteType, Integer resolutionStatus,
+        String module, Locale locale
+    ) {
+        this.viewNotesService = viewNotesService;
+        this.currentStudy = currentStudy;
+        this.discNoteType = discNoteType;
+        this.resolutionStatus = resolutionStatus;
+        this.module = module;
+        this.resword = ResourceBundleProvider.getWordsBundle(locale);
+        this.resformat = ResourceBundleProvider.getFormatBundle(locale);
+
+        ResourceBundle resterm = ResourceBundleProvider.getTermsBundle(locale);
+        this.discNoteTypeFilterOptions = buildDiscNoteTypeFilterOptions(resterm);
+        this.resolutionStatusFilterOptions = buildResolutionStatusFilterOptions(resterm);
+        this.discNoteTypeDecoder = identityDecoder(discNoteTypeFilterOptions);
+        this.resolutionStatusDecoder = identityDecoder(resolutionStatusFilterOptions);
+
+        // "type", "resolutionStatus", and "module" are top-level sticky parameters used for download/print links.
+        this.table = new LCTable<>("listNotes", buildColumns(), this::fetchData, List.of("module", "type", "resolutionStatus"));
+
+        // Only show download/print links (and their separators) if the current page has rows.
+        java.util.function.Predicate<LCTableContext<DiscrepancyNoteBean>> hasContent = ctx -> !ctx.data.pageItems.isEmpty();
+        this.table.addCustomToolbarControl(hasContent, this::renderDownloadControl);
+        this.table.addCustomToolbarControl(hasContent, this::renderPrintControl);
+    }
+
+    // -- Filter option types for the "type"/"resolution status" column dropdowns (label/value decoding) ------------
+    //
+    // Neither DiscrepancyNoteType nor ResolutionStatus alone is enough here: the legacy dropdown filters
+    // also offer one extra, combined option each ("Query_and_Failed_Validation_Check" -> "1,3",
+    // "New_and_Updated" -> "1,2"), submitted as a comma-separated id list that the SQL "in (...)" filter fragment
+    // accepts directly (see viewnotes.properties). This small typed option class models exactly that: a
+    // (submitted id/ids, display label) pair -- preferred here over a loose Map<String,String> per the project's
+    // type-safety conventions.
+    private static final class NoteFilterOption {
+        private final String urlParam;
+        private final String label;
+
+        NoteFilterOption(String urlParam, String label) {
+            this.urlParam = urlParam;
+            this.label = label;
+        }
+
+        String getUrlParam() {
+            return urlParam;
+        }
+
+        String getLabel() {
+            return label;
+        }
+    }
+
+    private static List<NoteFilterOption> buildDiscNoteTypeFilterOptions(ResourceBundle resterm) {
+        List<NoteFilterOption> options = new ArrayList<>();
+        for (DiscrepancyNoteType type : DiscrepancyNoteType.list) {
+            options.add(new NoteFilterOption(Integer.toString(type.getId()), type.getName()));
+        }
+        options.add(new NoteFilterOption("1,3", resterm.getString("Query_and_Failed_Validation_Check")));
+        return options;
+    }
+
+    private static List<NoteFilterOption> buildResolutionStatusFilterOptions(ResourceBundle resterm) {
+        List<NoteFilterOption> options = new ArrayList<>();
+        for (ResolutionStatus status : ResolutionStatus.list) {
+            options.add(new NoteFilterOption(Integer.toString(status.getId()), status.getName()));
+        }
+        options.add(new NoteFilterOption("1,2", resterm.getString("New_and_Updated")));
+        return options;
+    }
+
+    /**
+     * {@link LCTableFilterDef.Select} submits the id/ids string directly as the URL parameter value (see
+     * {@code NoteFilterOption#getUrlParam()}), rather than a display label needing decoding -- so the decoder
+     * maps required by {@link ViewNotesFilterCriteria#buildFilterCriteria(Map, String, Map, Map)} are simply
+     * identity maps.
+     */
+    private static Map<String, String> identityDecoder(List<NoteFilterOption> options) {
+        Map<String, String> decoder = new HashMap<>();
+        for (NoteFilterOption option : options) {
+            decoder.put(option.getUrlParam(), option.getUrlParam());
+        }
+        return decoder;
+    }
+
+    // -- Element id helper -------------------------------------------------------------------------
+
+    /** Per-row action id, prefixed with the table's name (e.g., "listNotes-view-123"). */
+    private String actionId(String action, DiscrepancyNoteBean row) {
+        return actionId(action) + "-" + row.getId();
+    }
+
+    /** Toolbar-level action id, prefixed with the table's name (e.g., "listNotes-download"). */
+    private String actionId(String action) {
+        return table.getTableName() + "-" + action;
+    }
+
+    // -- Toolbar: "download all" / "print" links (custom, non-tabular toolbar controls) --------------
+
+    /**
+     * Renders the "download all discrepancy notes" toolbar icon link.
+     * Only shown when the current page has content.
+     */
+    private void renderDownloadControl(Div<?> container, LCTableContext<DiscrepancyNoteBean> ctx) {
+        // Rebuilds the "ChooseDownloadFormat" URL including current filter/sort states and sticky
+        // parameters (resolutionStatus, discNoteType, module) to ensure the export matches the table view.
+        SafeUrl downloadHref = url("ChooseDownloadFormat")
+            .param("resolutionStatus", resolutionStatus)
+            .param("discNoteType", discNoteType)
+            .param("module", module);
+        ctx.filters.forEach(downloadHref::param);
+        if (ctx.sortProp != null && !ctx.sortProp.isEmpty()) {
+            // Must uppercase sortDir because DiscrepancyNoteOutputServlet expects "ASC"/"DESC".
+            downloadHref.param("sort." + ctx.sortProp, ctx.sortDir.toUpperCase(Locale.ROOT));
+        }
+
+        container.of(LCTableUtil.actionLink(actionId("download"), resword.getString("download_all_discrepancy_notes"),
+            "javascript:openDocWindow('" + downloadHref.toUriString() + "')", "bt_Download.gif"));
+    }
+
+    /**
+     * Renders the "print discrepancy notes" toolbar icon link.
+     * Only shown when the current page has content.
+     */
+    private void renderPrintControl(Div<?> container, LCTableContext<DiscrepancyNoteBean> ctx) {
+        // Rebuilds a clean "ViewNotes...&print=yes" URL including current filters and sort state.
+        // Deliberately omits pagination params (page, maxRows, showHiddenCols) as they are ignored
+        // by findAllNotes(request), and omits discNoteType/resolutionStatus which are unused here.
+        SafeUrl printHref = url("ViewNotes")
+            .param("module", module)
+            .param("print", "yes");
+        ctx.filters.forEach((prop, val) -> printHref.param(LCTableParams.PARAM_FILTER_PREFIX + prop, val));
+        if (ctx.sortProp != null && !ctx.sortProp.isEmpty()) {
+            printHref.param(LCTableParams.PARAM_SORT_PROP, ctx.sortProp).param(LCTableParams.PARAM_SORT_DIR, ctx.sortDir);
+        }
+
+        container.of(LCTableUtil.actionLink(actionId("print"), resword.getString("print"),
+            "javascript:openDocWindow('" + printHref.toUriString() + "')", "bt_Print.gif"));
+    }
+
+    // -- Column definitions --------------------------------------------------------------------------
+
+    private List<LCTableColumnDef<DiscrepancyNoteBean>> buildColumns() {
+        List<LCTableColumnDef<DiscrepancyNoteBean>> columns = new ArrayList<>();
+
+        columns.add(textCol("studySubject.label", resword.getString("study_subject_ID"), 0, row -> row.getStudySub().getLabel()));
+
+        columns.add(customTdCol("discrepancyNoteBean.disType", resword.getString("type"), 0, NOT_SORTABLE,
+            new LCTableFilterDef.Select<>(discNoteTypeFilterOptions, NoteFilterOption::getLabel, NoteFilterOption::getUrlParam),
+            this::renderNoteTypeCell
+        ));
+
+        columns.add(customTdCol("discrepancyNoteBean.resolutionStatus", resword.getString("resolution_status"), 0, NOT_SORTABLE,
+            new LCTableFilterDef.Select<>(resolutionStatusFilterOptions, NoteFilterOption::getLabel, NoteFilterOption::getUrlParam),
+            this::renderResolutionStatusCell
+        ));
+
+        columns.add(customTdCol("siteId", resword.getString("site_id"), 0, NOT_SORTABLE, textFilter(),
+            (td, row) -> td.text(orPlaceholder(row.getSiteId()))
+        ));
+
+        columns.add(textColHidden("discrepancyNoteBean.createdDate", resword.getString("date_created"), 0,
+            DiscrepancyNoteBean::getCreatedDate, this::formatDate
+        ));
+
+        columns.add(customTdColHidden("discrepancyNoteBean.updatedDate", resword.getString("date_updated"), 0, NOT_SORTABLE, textFilter(),
+            (td, row) -> td.text(row.getUpdatedDate() == null ? NULL_PLACEHOLDER : formatDate(row.getUpdatedDate()))
+        ));
+
+        columns.add(textCol("age", resword.getString("days_open"), 0, textFilter("\\d*", "Please enter digits only"),
+            DiscrepancyNoteBean::getAge, Object::toString
+        ));
+        columns.add(textCol("days", resword.getString("days_since_updated"), 0, textFilter("\\d*", "Please enter digits only"),
+            DiscrepancyNoteBean::getDays, Object::toString
+        ));
+
+        columns.add(customTdCol("eventName", resword.getString("event_name"), 0, NOT_SORTABLE, textFilter(),
+            (td, row) -> td.text(orPlaceholder(row.getEventName()))
+        ));
+
+        columns.add(customTdColHidden("eventStartDate", resword.getString("event_date"), 0, NOT_SORTABLE, NO_FILTER,
+            (td, row) -> td.text(row.getEventStart() == null ? NULL_PLACEHOLDER : formatDate(row.getEventStart()))
+        ));
+
+        columns.add(customTdCol("crfName", resword.getString("CRF"), 0, NOT_SORTABLE, textFilter(),
+            (td, row) -> td.text(orPlaceholder(row.getCrfName()))
+        ));
+
+        columns.add(customTdColHidden("crfStatus", resword.getString("CRF_status"), 0, NOT_SORTABLE, NO_FILTER,
+            (td, row) -> td.text(orPlaceholder(row.getCrfStatus()))
+        ));
+
+        columns.add(customTdCol("entityName", resword.getString("entity_name"), 0, NOT_SORTABLE, textFilter(),
+            (td, row) -> td.text(entityNameLabel(row))
+        ));
+
+        columns.add(customTdCol("entityValue", resword.getString("entity_value"), 0, NOT_SORTABLE, textFilter(),
+            (td, row) -> td.text(orPlaceholder(row.getEntityValue()))
+        ));
+
+        columns.add(customTdColHidden("discrepancyNoteBean.entityType", resword.getString("entity_type"), 0, NOT_SORTABLE, textFilter(),
+            (td, row) -> td.text(orPlaceholder(row.getEntityType()))
+        ));
+
+        columns.add(customTdCol("discrepancyNoteBean.description", resword.getString("description"), 0, NOT_SORTABLE, textFilter(),
+            (td, row) -> td.text(orPlaceholder(row.getDescription()))
+        ));
+
+        columns.add(customTdColHidden("discrepancyNoteBean.detailedNotes", resword.getString("detailed_notes"), 0, NOT_SORTABLE, NO_FILTER,
+            (td, row) -> td.text(orPlaceholder(row.getDetailedNotes()))
+        ));
+
+        columns.add(customTdColHidden("numberOfNotes", resword.getString("of_notes"), 0, NOT_SORTABLE, NO_FILTER,
+            (td, row) -> td.text(Integer.toString(row.getNumChildren()))
+        ));
+
+        columns.add(customTdCol("discrepancyNoteBean.user", resword.getString("assigned_user"), 0, NOT_SORTABLE, textFilter(),
+            this::renderAssignedUserCell
+        ));
+
+        columns.add(customTdColHidden("discrepancyNoteBean.owner", resword.getString("owner"), 0, NOT_SORTABLE, NO_FILTER,
+            this::renderOwnerCell
+        ));
+
+        columns.add(customTdCol("actions", resword.getString("actions"), 0, NOT_SORTABLE, clearFilter(), this::renderActionsCell));
+
+        return columns;
+    }
+
+    // -- Cell renderers -------------------------------------------------------------------------------
+
+    private static String orPlaceholder(String s) {
+        return s == null ? NULL_PLACEHOLDER : s;
+    }
+
+    private void renderNoteTypeCell(Td<?> td, DiscrepancyNoteBean row) {
+        DiscrepancyNoteType type = row.getDisType();
+        td.text(type == null ? NULL_PLACEHOLDER : type.getName());
+    }
+
+    private void renderResolutionStatusCell(Td<?> td, DiscrepancyNoteBean row) {
+        ResolutionStatus status = row.getResStatus();
+        if (status == null) {
+            td.text(NULL_PLACEHOLDER);
+            return;
+        }
+        Td<?> afterIcon = td.img().attrSrc(status.getIconFilePath()).attrAlt(status.getName()).__();
+        afterIcon.text(" " + status.getName());
+    }
+
+    /** Entity names for non-itemData rows are resource-bundle keys. */
+    private String entityNameLabel(DiscrepancyNoteBean row) {
+        String entityName = row.getEntityName();
+        if (DiscrepancyNoteBean.ITEM_DATA.equals(row.getEntityType())) {
+            return orPlaceholder(entityName);
+        }
+        try {
+            return resword.getString(entityName);
+        } catch (MissingResourceException e) {
+            return "###" + entityName + "###";
+        }
+    }
+
+    private void renderAssignedUserCell(Td<?> td, DiscrepancyNoteBean row) {
+        UserAccountBean user = row.getAssignedUser();
+        if (user == null || user.getName() == null || user.getName().isEmpty()) {
+            td.text(NULL_PLACEHOLDER);
+        } else {
+            td.text(user.getFirstName() + " " + user.getLastName() + " (" + user.getName() + ")");
+        }
+    }
+
+    private void renderOwnerCell(Td<?> td, DiscrepancyNoteBean row) {
+        UserAccountBean owner = row.getOwner();
+        td.text(owner == null || owner.getName() == null || owner.getName().isEmpty() ? NULL_PLACEHOLDER : owner.getName());
+    }
+
+    /** Renders action links (see class javadoc for intentional legacy parity fix/omission). */
+    private void renderActionsCell(Td<?> td, DiscrepancyNoteBean row) {
+        String createNoteUrl = CreateDiscrepancyNoteServlet.getAddChildURL(row, ResolutionStatus.CLOSED, true) + "&viewAction=1";
+        td.of(LCTableUtil.actionLink(actionId("view", row), resword.getString("view"), "javascript:openDNWindow('" + createNoteUrl + "');", "bt_View.gif"));
+
+        if (!currentStudy.getStatus().isLocked()) {
+            // Fixed: the legacy renderer compared getEntityType() != "eventCrf" by reference instead of by value.
+            boolean isEventCrf = "eventCrf".equals(row.getEntityType());
+            if (!isEventCrf || row.getStageId() == 5) {
+                td.of(LCTableUtil.actionLink(actionId("resolve", row), resword.getString("view_within_crf"),
+                    url("ResolveDiscrepancy").param("noteId", row.getId()), "bt_Reassign.gif"));
+            }
+        }
+
+        // NOTE: the legacy jmesa ActionsCellEditor also built a per-row "download discrepancy notes" link here
+        // (see the now-removed downloadNotesLinkBuilder(studySubjectBean)), but never actually appended it to the
+        // rendered HTML -- a pre-existing dead-code bug, intentionally preserved (not restored) in this migration.
+        // If the per-row download icon is ever wanted back, this is the place to add it, reusing the same
+        // "ChooseDownloadFormat?subjectId=...&discNoteType=...&resolutionStatus=...(&module=...)" URL pattern
+        // as the toolbar-level "download all" link built in #renderDownloadAndPrintControls.
+    }
+
+    // -- Date formatting --------------------------------------------------------------------------------
+
+    private String getDateFormat() {
+        return resformat.getString("date_format_string");
+    }
+
+    private String formatDate(Date date) {
+        return new SimpleDateFormat(getDateFormat()).format(date);
+    }
+
+    // -- HIDDEN column factories --
+    // Provides HIDDEN equivalents for LCTableColumnDef.customTdCol(...) with null-safety.
+    private static LCTableColumnDef<DiscrepancyNoteBean> customTdColHidden(
+        String columnName, String displayName, double width, LCTableColumnDef.Sortability sortability, LCTableFilterDef filterDef,
+        BiConsumer<Td<?>, DiscrepancyNoteBean> renderer
+    ) {
+        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, sortability, filterDef, (tr, row) -> {
+            Td<?> td = tr.td().attrClass("lc-col-" + columnName);
+            if (row == null) {
+                td.text(NULL_PLACEHOLDER);
+            } else {
+                renderer.accept(td, row);
+            }
+            td.__();
+        });
+    }
+
+    // -- Data fetching -----------------------------------------------------------------------------
+
+    private LCTableData<DiscrepancyNoteBean> fetchData(LCTableParams p) {
+        ViewNotesFilterCriteria filter = ViewNotesFilterCriteria.buildFilterCriteria(p.filters, getDateFormat(), discNoteTypeDecoder,
+            resolutionStatusDecoder);
+
+        DiscrepancyNotesSummary summary = viewNotesService.calculateNotesSummary(currentStudy, filter);
+        this.notesSummary = summary;
+        int total = summary.getTotal();
+
+        // If requested page exceeds dataset size, fetch the last page instead (preserves legacy behaviour).
+        int pageSize = p.maxRows;
+        int firstRecordShown = p.page * pageSize;
+        int effectivePage1Based = (total != 0 && firstRecordShown > total) ? (int) Math.ceil((double) total / pageSize) : p.page + 1;
+
+        filter.withPagination(effectivePage1Based, pageSize);
+        ViewNotesSortCriteria sort = ViewNotesSortCriteria.buildFilterCriteria(p.sortProp, p.sortDir);
+        List<DiscrepancyNoteBean> items = viewNotesService.listNotes(currentStudy, filter, sort);
+
+        return new LCTableData<>(items, total);
+    }
+
+    /** Notes summary computed during the last {@link #fetchData}/{@link #render} call. */
+    public DiscrepancyNotesSummary getNotesSummary() {
+        return notesSummary;
+    }
+
+    /** Fetches all notes matching current filters/sort (unpaginated) for the "print" flow. */
+    public List<DiscrepancyNoteBean> findAllNotes(HttpServletRequest request) {
+        LCTableParams params = new LCTableParams(request.getQueryString(), this.table);
+        ViewNotesFilterCriteria filter = ViewNotesFilterCriteria.buildFilterCriteria(params.filters, getDateFormat(), discNoteTypeDecoder,
+            resolutionStatusDecoder);
+        ViewNotesSortCriteria sort = ViewNotesSortCriteria.buildFilterCriteria(params.sortProp, params.sortDir);
+        return viewNotesService.listNotes(currentStudy, filter, sort);
+    }
+
+    // -- Rendering entry point ---------------------------------------------------------------------
+
+    public String render(HttpServletRequest request) {
+        LCTableParams params = new LCTableParams(request.getQueryString(), this.table);
+        return this.table.render(request.getRequestURI(), params, request.getContextPath());
+    }
+
+}

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableToolbar.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTableToolbar.java
@@ -5,7 +5,7 @@
  * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
- * copyright (C) 2020 - 2024 LibreClinica
+ * copyright (C) 2020 - 2026 LibreClinica
  */
 package org.akaza.openclinica.control.submit;
 
@@ -232,7 +232,7 @@ public class ListNotesTableToolbar extends DefaultToolbar {
         public String enabled() {
             HtmlBuilder html = new HtmlBuilder();
             html.a().href("#");
-            html.onclick("javascript:openPopup()");
+            html.onclick("javascript:openPopup(); return false;");
             html.quote();
             html.append(getAction());
             html.quote().close();

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
@@ -58,7 +58,24 @@ public class LCTable<T>  {
      * Optional extra controls (e.g., custom action links or dropdowns) rendered in the toolbar
      * after the built-in controls. Added via {@link #addCustomToolbarControl} before rendering.
      */
-    private final List<BiConsumer<Div<?>, LCTableContext<T>>> customToolbarControls = new ArrayList<>();
+    private final List<CustomToolbarControl<T>> customToolbarControls = new ArrayList<>();
+
+    /**
+     * Pairs a custom toolbar control's renderer with a predicate deciding, from the context alone (i.e.
+     * without actually rendering anything), whether the control has any content to show for the current
+     * request. This lets {@link #renderToolbar} skip the control's leading separator {@code <div>} when the
+     * control would render nothing (e.g. {@code ListNotesTable}'s "download all"/"print" links, hidden when
+     * the current page has no rows) -- instead of always rendering a separator followed by an empty control.
+     */
+    private static final class CustomToolbarControl<T> {
+        final java.util.function.Predicate<LCTableContext<T>> hasContent;
+        final BiConsumer<Div<?>, LCTableContext<T>> render;
+
+        CustomToolbarControl(java.util.function.Predicate<LCTableContext<T>> hasContent, BiConsumer<Div<?>, LCTableContext<T>> render) {
+            this.hasContent = hasContent;
+            this.render = render;
+        }
+    }
 
     // constants to control table behaviour
     static final boolean HIDE_PAGINATION_TOOLS_FOR_SINGLE_PAGE_TABLE = false;
@@ -88,11 +105,26 @@ public class LCTable<T>  {
 
     /**
      * Appends a custom control to the toolbar, rendered after built-in controls. Must be called before rendering.
+     * The control is assumed to always render some content; use {@link #addCustomToolbarControl(java.util.function.Predicate, BiConsumer)}
+     * for a control that may legitimately render nothing for some requests.
      *
      * @param control closure that renders the control's markup into the toolbar's container {@code <div>}
      */
     public void addCustomToolbarControl(BiConsumer<Div<?>, LCTableContext<T>> control) {
-        customToolbarControls.add(Objects.requireNonNull(control, "control"));
+        addCustomToolbarControl(ctx -> true, control);
+    }
+
+    /**
+     * Appends a custom control to the toolbar, rendered after built-in controls, but only when {@code hasContent}
+     * returns true for the current context -- in which case its leading separator is rendered too. Must be
+     * called before rendering.
+     *
+     * @param hasContent decides, from the context alone, whether the control has anything to render this request
+     * @param control    closure that renders the control's markup into the toolbar's container {@code <div>}
+     */
+    public void addCustomToolbarControl(java.util.function.Predicate<LCTableContext<T>> hasContent, BiConsumer<Div<?>, LCTableContext<T>> control) {
+        customToolbarControls.add(new CustomToolbarControl<>(
+            Objects.requireNonNull(hasContent, "hasContent"), Objects.requireNonNull(control, "control")));
     }
 
     /** True if this table declares at least one column with HIDDEN visibility. */
@@ -190,10 +222,13 @@ public class LCTable<T>  {
                         .__();
                 }
                 // Custom, non-tabular controls (see addCustomToolbarControl), in the order they were added --
-                // each preceded by the same separator used between the built-in controls above.
+                // each preceded by the same separator used between the built-in controls above, but only when
+                // the control actually has something to render for this request (see CustomToolbarControl).
                 customToolbarControls.forEach(control -> {
-                    container.div().attrClass("toolbar-separator").__();
-                    control.accept(container, ctx);
+                    if (control.hasContent.test(ctx)) {
+                        container.div().attrClass("toolbar-separator").__();
+                        control.render.accept(container, ctx);
+                    }
                 });
             }).__();
     }

--- a/web/src/main/webapp/WEB-INF/jsp/managestudy/viewNotes.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/managestudy/viewNotes.jsp
@@ -14,22 +14,34 @@
     </c:otherwise>
 </c:choose>
 
-<link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa.js"></script>
-<script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery-migrate-3.4.1.min.js"></script>
-<script type="text/javascript">
-    function onInvokeAction(id,action) {
-        if(id.indexOf('listNotes') == -1)  {
-        setExportToLimit(id, '');
+<%-- JMesa scripts are only needed when the JMesa rendering path is active. --%>
+<c:choose>
+    <c:when test="${tableRenderingMode == 'jmesa'}">
+        <link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
+    </c:when>
+    <c:otherwise>
+        <link rel="stylesheet" href="includes/lctable/lctable.css" type="text/css">
+    </c:otherwise>
+</c:choose>
+<c:if test="${tableRenderingMode == 'jmesa'}">
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa.js"></script>
+    <script type="text/javascript" language="JavaScript" src="includes/jmesa/jquery-migrate-3.4.1.min.js"></script>
+    <script type="text/javascript">
+        function onInvokeAction(id,action) {
+            if(id.indexOf('listNotes') == -1)  {
+            setExportToLimit(id, '');
+            }
+            createHiddenInputFieldsForLimitAndSubmit(id);
         }
-        createHiddenInputFieldsForLimitAndSubmit(id);
-    }
-    function onInvokeExportAction(id) {
-        var parameterString = createParameterStringForLimit(id);
-        location.href = '${pageContext.request.contextPath}/ViewNotes?'+ parameterString;
-    }
+        function onInvokeExportAction(id) {
+            var parameterString = createParameterStringForLimit(id);
+            location.href = '${pageContext.request.contextPath}/ViewNotes?'+ parameterString;
+        }
+    </script>
+</c:if>
+<script type="text/javascript">
     function openPopup() {
         openDocWindow(window.location.href +'&print=yes')
     }
@@ -160,10 +172,28 @@
     <!-- End Of New Summary -->
 </div>
 
-<form  action="${pageContext.request.contextPath}/ViewNotes" style="clear:left; float:left;">
-        <input type="hidden" name="module" value="submit">
-        ${viewNotesHtml}
-    </form>
+<%-- IMPORTANT: the LCTable (HtmlFlow) rendering path renders its own <form> around the whole
+     table (see LCTable.renderTableHtml()) -- it must NOT also be wrapped in a <form> here, or
+     the two nested <form>s would collide (nested <form>s are invalid HTML; the inner start tag
+     is simply dropped by the parser), causing this JSP's own hidden "module" input to collide
+     with LCTable's own "module" sticky-parameter hidden input once both are serialized together
+     by HTMX's "closest form" -- see LCTable's class-level javadoc for details, and see the
+     analogous fix in admin/auditUserActivity.jsp and managestudy/listEventsForSubjects.jsp.
+     Only the legacy JMesa rendering path (native form-based pagination/sort/filter resubmission,
+     via createHiddenInputFieldsForLimitAndSubmit()) actually needs a surrounding <form>. --%>
+<c:choose>
+    <c:when test="${tableRenderingMode == 'jmesa'}">
+        <form  action="${pageContext.request.contextPath}/ViewNotes" style="clear:left; float:left;">
+            <input type="hidden" name="module" value="submit">
+            ${viewNotesHtml}
+        </form>
+    </c:when>
+    <c:otherwise>
+        <div style="clear:left; float:left;">
+            ${viewNotesHtml}
+        </div>
+    </c:otherwise>
+</c:choose>
 <!-- EXPANDING WORKFLOW BOX -->
 
 <div style="clear:left">
@@ -251,4 +281,9 @@
 </div>
 
 <!-- END WORKFLOW BOX -->
+
+<!-- Include everything that is needed for proper use of HTMX with LCTable (only needed for the htmlflow path,
+     but harmless to include unconditionally since it's small and self-contained) -->
+<jsp:include page="../include/useLCTable.jsp"/>
+
 <jsp:include page="../include/footer.jsp"/>

--- a/web/src/main/webapp/includes/lctable/lctable.css
+++ b/web/src/main/webapp/includes/lctable/lctable.css
@@ -258,6 +258,7 @@
     font-size: 12px;
     font-weight: normal;
     padding: 5px 9px;
+    border: 2px solid #ffffff;
     border-radius: 6px;
     white-space: nowrap;
     box-shadow: 1px 2px 5px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
First working implementation of LCTable-based `listNotes` table replacing the corresponding legacy jmesa table (see https://github.com/reliatec-gmbh/LibreClinica/issues/74).

This is the 4th migrated jmesa table. It is configured by the `ListNotesTable` class (see also https://github.com/reliatec-gmbh/LibreClinica/wiki/jmesa-tables-migration:-progress-and-to-do).

Summary of code changes:

1. `listNotes` table:
   - `ListNotesTable`: new class for configuring the `listNotes` table
   - `ViewNotesServlet`: usual adaptations in servlet (analogous to PR #471, for example)
   - `viewNotes.jsp`: usual adaptations in JSP template (analogous to PR #471, for example)
   - `ViewNotesSortCriteria`, `ViewNotesFilterCriteria`: adapter methods needed for interfacing with LCTable (no breaking changes, only additions)

2. LCTable library:
   - `LCTable`: minor addition for improved layout: conditional additional of custom toolbar controls (needed in this table because download and print icons should not appear in toolbar if table is empty)
   - `lctable.css`: added white border to LCTable tooltips for better visibiity against background of a same/similar colour