### PR TITLE
Implementation of test attributes (`data-test*`) for LCTable-based tables.

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/admin/AuditUserLoginTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/admin/AuditUserLoginTable.java
@@ -36,7 +36,8 @@ public class AuditUserLoginTable {
     // constructor (takes DAO as parameter and initializes the LCTable with column definitions and fetchData method)
     public AuditUserLoginTable(AuditUserLoginDao auditUserLoginDao) {
         this.auditUserLoginDao = auditUserLoginDao;
-        this.table = new LCTable<>("userLogins", COLUMNS, this::fetchData);
+        this.table = new LCTable<>("userLogins", COLUMNS, this::fetchData)
+            .setRowTestAttributes(row -> java.util.Map.of("login", String.valueOf(row.getId())));
     }
 
     /**
@@ -70,7 +71,7 @@ public class AuditUserLoginTable {
             AuditUserLoginBean::getUserAccountId,
             (td, row) ->
                 td.of(actionLink(actionId("view", row), "View",
-                    url("ViewUserAccount").param("userId", row.getUserAccountId()).param("viewFull", "yes"), "bt_View.gif"))
+                    url("ViewUserAccount").param("userId", row.getUserAccountId()).param("viewFull", "yes"), "bt_View.gif", "view"))
         )
     );
 

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ListEventsForSubjectTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ListEventsForSubjectTable.java
@@ -195,6 +195,7 @@ public class ListEventsForSubjectTable {
             .of(div -> {
                 div.label().text(resword.getString("events") + ": ").__();
                 div.select()
+                    .addAttr("data-testid", "select-event-definition")
                     .addAttr("onchange",
                         "var v=this.value; if (v == '0') { window.location='" + ctx.resourcePath + "/ListStudySubjects'; } "
                             + "else if (v) { window.location='" + ctx.resourcePath + "/ListEventsForSubjects?module=submit&defId=' + v; }")
@@ -213,6 +214,7 @@ public class ListEventsForSubjectTable {
     /** Toolbar button opening the "Add New Subject" modal (JSP-side BlockUI overlay; unrelated to LCTable/HTMX). */
     private void renderAddNewSubjectControl(Div<?> container, LCTableContext<ListEventsForSubjectRow> ctx) {
         container.a().attrClass("text-btn").attrHref("javascript:;").attrId("addSubject")
+            .addAttr("data-testid", "add-subject-button")
             .text(resword.getString("add_new_subject"))
             .__();
     }

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ListEventsForSubjectTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ListEventsForSubjectTable.java
@@ -156,7 +156,8 @@ public class ListEventsForSubjectTable {
         this.eventPopup = EventStatusPopup.perOccurrence(selectedStudyEventDefinition, studyBean, currentRole, currentUser, resword, resformat);
         this.crfPopup = CrfStatusPopup.perOccurrence(selectedStudyEventDefinition, studyBean, currentRole, currentUser, crfVersionDAO, resword, resformat, contextPath);
 
-        this.table = new LCTable<>("listEventsForSubject", buildColumns(), this::fetchData, List.of("defId"));
+        this.table = new LCTable<>("listEventsForSubject", buildColumns(), this::fetchData, List.of("defId"))
+            .setRowTestAttributes(row -> Map.of("subject", row.studySubject.getLabel()));
         this.table.addCustomToolbarControl(this::renderSelectEventControl);
         if (isAddSubjectLinkShown()) {
             this.table.addCustomToolbarControl(this::renderAddNewSubjectControl);
@@ -252,10 +253,13 @@ public class ListEventsForSubjectTable {
 
         // one column per active top-level CRF of the selected event definition
         for (CRFBean crf : crfs) {
-            columns.add(customTdCol("crf_" + crf.getId(), crf.getName(), 0, NOT_SORTABLE,
+            LCTableColumnDef<ListEventsForSubjectRow> crfColumn = LCTableColumnDef.<ListEventsForSubjectRow>customTdCol(
+                "crf_" + crf.getId(), crf.getName(), 0, NOT_SORTABLE,
                 new LCTableFilterDef.Select<>(DataEntryStage.toArrayList(), DataEntryStage::getName, DataEntryStage::getName),
                 (td, row) -> renderCrfCell(td, row, crf)
-            ));
+            );
+            crfColumn.setTestAttributes(row -> Map.of("crf", crf.getName()));
+            columns.add(crfColumn);
         }
 
         columns.add(customTdCol("actions", resword.getString("rule_actions"), 0, NOT_SORTABLE, LCTableFilterDef.clearFilter(), this::renderActionsCell));
@@ -313,7 +317,7 @@ public class ListEventsForSubjectTable {
             return;
         }
         td.of(actionLink(actionId("view", studySubject.getId()), resword.getString("view"), url("ViewStudySubject").param("id", studySubject.getId()),
-            "bt_View.gif"));
+            "bt_View.gif", "view"));
 
         if (currentRole.getRole() == Role.MONITOR) {
             return;
@@ -326,19 +330,19 @@ public class ListEventsForSubjectTable {
             td.of(actionLink(actionId("remove", studySubject.getId()), resword.getString("remove"),
                 url("RemoveStudySubject").param("action", "confirm").param("id", studySubject.getId()).param("subjectId", studySubject.getSubjectId())
                     .param("studyId", studySubject.getStudyId()),
-                "bt_Remove.gif"));
+                "bt_Remove.gif", "remove"));
         }
         if (studyAvailable && subjectDeleted) {
             td.of(actionLink(actionId("restore", studySubject.getId()), resword.getString("restore"),
                 url("RestoreStudySubject").param("action", "confirm").param("id", studySubject.getId()).param("subjectId", studySubject.getSubjectId())
                     .param("studyId", studySubject.getStudyId()),
-                "bt_Restore.gif"));
+                "bt_Restore.gif", "restore"));
         }
         if (studyAvailable && studySubject.getStatus() == Status.AVAILABLE
             && currentRole.getRole() != Role.INVESTIGATOR && currentRole.getRole() != Role.RESEARCHASSISTANT
             && currentRole.getRole() != Role.RESEARCHASSISTANT2) {
             td.of(actionLink(actionId("reassign", studySubject.getId()), resword.getString("reassign"), url("ReassignStudySubject").param("id",
-                studySubject.getId()), "bt_Reassign.gif"));
+                studySubject.getId()), "bt_Reassign.gif", "reassign"));
         }
     }
 

--- a/web/src/main/java/org/akaza/openclinica/control/popup/CrfStatusPopup.java
+++ b/web/src/main/java/org/akaza/openclinica/control/popup/CrfStatusPopup.java
@@ -92,7 +92,8 @@ public final class CrfStatusPopup {
     private static void renderTriggerIcon(Div<?> trigger, List<CrfOccurrenceData> items) {
         DataEntryStage stage = items.get(0).stage;
         String iconPath = CRF_STATUS_ICON_PATHS.get(stage.getId());
-        trigger.span().attrClass("lc-popup-status-badge")
+        trigger.span().attrClass("lc-popup-badge")
+            .addAttr("data-testid", "lc-popup-badge")
             .of(badge -> {
                 if (iconPath != null) {
                     badge.img().attrSrc(iconPath).attrAlt(stage.getName()).__();
@@ -189,7 +190,7 @@ public final class CrfStatusPopup {
             if (!currentRole.isMonitor() && studyAvailable) {
                 if (!hidden) {
                     actions.add(of(null, resword.getString("edit"),
-                        url("AdministrativeEditing").param("eventCRFId", eventCrf.getId()).param("exitTo", "ListStudySubjects"), "bt_Edit.gif", true));
+                        url("AdministrativeEditing").param("eventCRFId", eventCrf.getId()).param("exitTo", "ListStudySubjects"), "bt_Edit.gif", true, "edit"));
                 }
                 if (directorOrSysAdmin) {
                     actions.add(removeEventCrfLink(studySubject, crf, eventCrf, occurrenceKey, resword));
@@ -214,17 +215,17 @@ public final class CrfStatusPopup {
                     url("InitialDataEntry").param("eventDefinitionCRFId", edc.getId()).param("studyEventId", studyEvent.getId())
                         .param("subjectId", studySubject.getSubjectId()).param("eventCRFId", eventCrfId).param("crfVersionId", edc.getDefaultVersionId())
                         .param("exitTo", "ListStudySubjects"),
-                    "bt_Edit.gif", true));
+                    "bt_Edit.gif", true, "enter-data"));
             }
             if (!hidden) {
                 actions.add(of(null, resword.getString("view"),
                     url("ViewSectionDataEntry").param("eventDefinitionCRFId", edc.getId()).param("crfVersionId", edc.getDefaultVersionId())
                         .param("tabId", 1).param("exitTo", "ListStudySubjects"),
-                    "bt_View.gif", true));
+                    "bt_View.gif", true, "view"));
                 if (eventCrf == null) {
                     int sampleOrdinal = studyEvent == null ? 1 : studyEvent.getSampleOrdinal();
                     actions.add(ofRawHref(null, resword.getString("print"),
-                        printHref(contextPath, studyBean, studySubject, selectedSed, sampleOrdinal, edc.getDefaultCRF().getOid()), "bt_Print.gif", true));
+                        printHref(contextPath, studyBean, studySubject, selectedSed, sampleOrdinal, edc.getDefaultCRF().getOid()), "bt_Print.gif", true, "print"));
                 } else {
                     actions.add(printExistingCrfLink(studyBean, studySubject, studyEvent, eventCrf, crfVersionDAO, resword, contextPath, selectedSed));
                 }
@@ -238,7 +239,7 @@ public final class CrfStatusPopup {
                 actions.add(of("listEventsForSubject-restore-crf-" + studySubject.getId() + "-" + crf.getId() + "-" + occurrenceKey,
                     resword.getString("restore"),
                     url("RestoreEventCRF").param("action", "confirm").param("id", eventCrf.getId()).param("studySubId", studySubject.getId()),
-                    "bt_Restore.gif", true));
+                    "bt_Restore.gif", true, "restore"));
             }
         } else {
             // INITIAL_DATA_ENTRY / INITIAL_DATA_ENTRY_COMPLETE / DOUBLE_DATA_ENTRY
@@ -246,11 +247,11 @@ public final class CrfStatusPopup {
                 if (stage == DataEntryStage.INITIAL_DATA_ENTRY_COMPLETE || stage == DataEntryStage.DOUBLE_DATA_ENTRY) {
                     actions.add(of("listEventsForSubject-double-data-entry-crf-" + eventCrf.getStudySubjectId() + "-" + crf.getId() + "-" + occurrenceKey,
                         resword.getString("enter_data"),
-                        url("DoubleDataEntry").param("eventCRFId", eventCrf.getId()).param("exitTo", "ListStudySubjects"), "bt_Edit.gif", true));
+                        url("DoubleDataEntry").param("eventCRFId", eventCrf.getId()).param("exitTo", "ListStudySubjects"), "bt_Edit.gif", true, "enter-data"));
                 } else {
                     actions.add(of("listEventsForSubject-enter-data-crf-" + eventCrf.getStudySubjectId() + "-" + crf.getId() + "-" + occurrenceKey,
                         resword.getString("enter_data"),
-                        url("InitialDataEntry").param("eventCRFId", eventCrf.getId()).param("exitTo", "ListStudySubjects"), "bt_Edit.gif", true));
+                        url("InitialDataEntry").param("eventCRFId", eventCrf.getId()).param("exitTo", "ListStudySubjects"), "bt_Edit.gif", true, "enter-data"));
                 }
             }
             if (!hidden) {
@@ -271,21 +272,21 @@ public final class CrfStatusPopup {
         return of(null, resword.getString("view"),
             url("ViewSectionDataEntry").param("eventDefinitionCRFId", edc.getId()).param("ecId", eventCrf.getId())
                 .param("tabId", 1).param("exitTo", "ListStudySubjects"),
-            "bt_View.gif", true);
+            "bt_View.gif", true, "view");
     }
 
     private static PopupAction removeEventCrfLink(StudySubjectBean studySubject, CRFBean crf, EventCRFBean eventCrf, int occurrenceKey,
             ResourceBundle resword) {
         return of("listEventsForSubject-remove-crf-" + studySubject.getId() + "-" + crf.getId() + "-" + occurrenceKey, resword.getString("remove"),
             url("RemoveEventCRF").param("action", "confirm").param("id", eventCrf.getId()).param("studySubId", studySubject.getId()),
-            "bt_Remove.gif", true);
+            "bt_Remove.gif", true, "remove");
     }
 
     private static PopupAction deleteEventCrfLink(StudySubjectBean studySubject, CRFBean crf, EventCRFBean eventCrf, int occurrenceKey,
             ResourceBundle resword) {
         return of("listEventsForSubject-delete-crf-" + studySubject.getId() + "-" + crf.getId() + "-" + occurrenceKey, resword.getString("delete"),
             url("DeleteEventCRF").param("action", "confirm").param("ssId", studySubject.getId()).param("ecId", eventCrf.getId()),
-            "bt_Delete.gif", true);
+            "bt_Delete.gif", true, "delete");
     }
 
     /** REST print link for an existing event CRF (mirrors {@code EventCrfLayerBuilder.printDataEntry(...)}). */
@@ -294,7 +295,7 @@ public final class CrfStatusPopup {
         CRFVersionBean crfVersion = crfVersionDAO.findByPK(eventCrf.getCRFVersionId());
         int sampleOrdinal = studyEvent == null ? 1 : studyEvent.getSampleOrdinal();
         String href = printHref(contextPath, studyBean, studySubject, selectedSed, sampleOrdinal, crfVersion.getOid());
-        return ofRawHref(null, resword.getString("print"), href, "bt_Print.gif", true);
+        return ofRawHref(null, resword.getString("print"), href, "bt_Print.gif", true, "print");
     }
 
     private static String printHref(String contextPath, StudyBean studyBean, StudySubjectBean studySubject, StudyEventDefinitionBean sed,

--- a/web/src/main/java/org/akaza/openclinica/control/popup/EventStatusPopup.java
+++ b/web/src/main/java/org/akaza/openclinica/control/popup/EventStatusPopup.java
@@ -123,7 +123,8 @@ public final class EventStatusPopup {
 
     private static void renderBadge(Div<?> trigger, SubjectEventStatus status, int count, boolean showCount) {
         String iconPath = EVENT_STATUS_ICON_PATHS.get(status.getId());
-        trigger.span().attrClass("lc-popup-status-badge")
+        trigger.span().attrClass("lc-popup-badge")
+            .addAttr("data-testid", "lc-popup-badge")
             .of(badge -> {
                 if (iconPath != null) {
                     badge.img().attrSrc(iconPath).attrAlt(status.getName()).__();
@@ -194,23 +195,23 @@ public final class EventStatusPopup {
         if (eventStatus == SubjectEventStatus.LOCKED) {
             if (studyDirectorOrSysAdmin) {
                 actions.add(of(actionIdPrefix + "view-occurrence-" + studyEvent.getId(), view,
-                    url("EnterDataForStudyEvent").param("eventId", studyEvent.getId()), "bt_View.gif", showLabel));
+                    url("EnterDataForStudyEvent").param("eventId", studyEvent.getId()), "bt_View.gif", showLabel, "view"));
                 if (studyAvailable) {
                     actions.add(of(actionIdPrefix + "remove-occurrence-" + studyEvent.getId(), resword.getString("remove"),
                         url("RemoveStudyEvent").param("action", "confirm").param("id", studyEvent.getId()).param("studySubId", studySubject.getId()),
-                        "bt_Remove.gif", showLabel));
+                        "bt_Remove.gif", showLabel, "remove"));
                 }
             }
             return actions;
         }
         actions.add(of(actionIdPrefix + "view-occurrence-" + studyEvent.getId(), view,
-            url("EnterDataForStudyEvent").param("eventId", studyEvent.getId()), "bt_View.gif", showLabel));
+            url("EnterDataForStudyEvent").param("eventId", studyEvent.getId()), "bt_View.gif", showLabel, "view"));
         if (studyDirectorOrSysAdmin && studyAvailable) {
             actions.add(of(actionIdPrefix + "edit-occurrence-" + studyEvent.getId(), resword.getString("edit"),
-                url("UpdateStudyEvent").param("event_id", studyEvent.getId()).param("ss_id", studySubject.getId()), "bt_Edit.gif", showLabel));
+                url("UpdateStudyEvent").param("event_id", studyEvent.getId()).param("ss_id", studySubject.getId()), "bt_Edit.gif", showLabel, "edit"));
             actions.add(of(actionIdPrefix + "remove-occurrence-" + studyEvent.getId(), resword.getString("remove"),
                 url("RemoveStudyEvent").param("action", "confirm").param("id", studyEvent.getId()).param("studySubId", studySubject.getId()),
-                "bt_Remove.gif", showLabel));
+                "bt_Remove.gif", showLabel, "remove"));
         }
         return actions;
     }
@@ -240,6 +241,8 @@ public final class EventStatusPopup {
                 header.a().attrClass("text-btn")
                     .attrHref("CreateNewStudyEvent?studySubjectId=" + ctx.studySubject.getId() + "&studyEventDefinition=" + sed.getId())
                     .attrId("findSubjects-add-occurrence-event-" + ctx.studySubject.getId() + "-" + sed.getId())
+                    .addAttr("data-testid", "action-link")
+                    .addAttr("data-test-action", "add-occurrence")
                     .text(resword.getString("add_another_occurrence"))
                     .__();
             }
@@ -265,7 +268,7 @@ public final class EventStatusPopup {
                     if (currentRole.getRole() != Role.MONITOR && !studyBean.getStatus().isFrozen()) {
                         actions.add(of("findSubjects-schedule-event-" + studySubject.getId() + "-" + sed.getId(), resword.getString("schedule"),
                             url("CreateNewStudyEvent").param("studySubjectId", studySubject.getId()).param("studyEventDefinition", sed.getId()),
-                            "bt_Schedule.gif", true));
+                            "bt_Schedule.gif", true, "schedule"));
                     }
                     return actions;
                 }
@@ -275,7 +278,7 @@ public final class EventStatusPopup {
                 if (eventSysStatus == Status.DELETED || eventSysStatus == Status.AUTO_DELETED) {
                     List<PopupAction> actions = new ArrayList<>();
                     actions.add(of("findSubjects-view-occurrence-" + studyEvent.getId(), resword.getString("view") + "/" + resword.getString("enter_data"),
-                        url("EnterDataForStudyEvent").param("eventId", studyEvent.getId()), "bt_View.gif", showLabel));
+                        url("EnterDataForStudyEvent").param("eventId", studyEvent.getId()), "bt_View.gif", showLabel, "view"));
                     return actions;
                 }
                 if (eventSysStatus.getId() != Status.AVAILABLE.getId() && eventSysStatus != Status.SIGNED) {
@@ -335,37 +338,37 @@ public final class EventStatusPopup {
                                 resword.getString("schedule"),
                                 url("CreateNewStudyEvent").param("studySubjectId", studySubject.getId())
                                     .param("studyEventDefinition", selectedSed.getId()),
-                                "bt_Schedule.gif", true));
+                                "bt_Schedule.gif", true, "schedule"));
                         }
                     } else if (eventStatus == SubjectEventStatus.LOCKED) {
                         if (studyDirectorOrSysAdmin) {
                             StudyEventBean se = studyEvent.get();
                             actions.add(of("listEventsForSubject-view-occurrence-" + se.getId(), view,
-                                url("EnterDataForStudyEvent").param("eventId", se.getId()), "bt_View.gif", true));
+                                url("EnterDataForStudyEvent").param("eventId", se.getId()), "bt_View.gif", true, "view"));
                             if (studyAvailable) {
                                 actions.add(of("listEventsForSubject-remove-occurrence-" + se.getId(), resword.getString("remove"),
                                     url("RemoveStudyEvent").param("action", "confirm").param("id", se.getId()).param("studySubId", studySubject.getId()),
-                                    "bt_Remove.gif", true));
+                                    "bt_Remove.gif", true, "remove"));
                             }
                         }
                     } else {
                         // COMPLETED and all other actual-occurrence statuses: identical action set in the legacy table
                         StudyEventBean se = studyEvent.get();
                         actions.add(of("listEventsForSubject-view-occurrence-" + se.getId(), view,
-                            url("EnterDataForStudyEvent").param("eventId", se.getId()), "bt_View.gif", true));
+                            url("EnterDataForStudyEvent").param("eventId", se.getId()), "bt_View.gif", true, "view"));
                         if (studyDirectorOrSysAdmin && studyAvailable) {
                             actions.add(of("listEventsForSubject-edit-occurrence-" + se.getId(), resword.getString("edit"),
-                                url("UpdateStudyEvent").param("event_id", se.getId()).param("ss_id", studySubject.getId()), "bt_Edit.gif", true));
+                                url("UpdateStudyEvent").param("event_id", se.getId()).param("ss_id", studySubject.getId()), "bt_Edit.gif", true, "edit"));
                             actions.add(of("listEventsForSubject-remove-occurrence-" + se.getId(), resword.getString("remove"),
                                 url("RemoveStudyEvent").param("action", "confirm").param("id", se.getId()).param("studySubId", studySubject.getId()),
-                                "bt_Remove.gif", true));
+                                "bt_Remove.gif", true, "remove"));
                         }
                     }
                 }
                 if ((eventSysStatus == Status.DELETED || eventSysStatus == Status.AUTO_DELETED) && studyEvent.isPresent()) {
                     StudyEventBean se = studyEvent.get();
                     actions.add(of("listEventsForSubject-view-occurrence-" + se.getId(), view,
-                        url("EnterDataForStudyEvent").param("eventId", se.getId()), "bt_View.gif", true));
+                        url("EnterDataForStudyEvent").param("eventId", se.getId()), "bt_View.gif", true, "view"));
                 }
                 return actions;
             }

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTable.java
@@ -89,7 +89,8 @@ public class ListNotesTable {
         this.resolutionStatusDecoder = identityDecoder(resolutionStatusFilterOptions);
 
         // "type", "resolutionStatus", and "module" are top-level sticky parameters used for download/print links.
-        this.table = new LCTable<>("listNotes", buildColumns(), this::fetchData, List.of("module", "type", "resolutionStatus"));
+        this.table = new LCTable<>("listNotes", buildColumns(), this::fetchData, List.of("module", "type", "resolutionStatus"))
+            .setRowTestAttributes(row -> Map.of("note", String.valueOf(row.getId())));
 
         // Only show download/print links (and their separators) if the current page has rows.
         java.util.function.Predicate<LCTableContext<DiscrepancyNoteBean>> hasContent = ctx -> !ctx.data.pageItems.isEmpty();
@@ -187,7 +188,7 @@ public class ListNotesTable {
         }
 
         container.of(LCTableUtil.actionLink(actionId("download"), resword.getString("download_all_discrepancy_notes"),
-            "javascript:openDocWindow('" + downloadHref.toUriString() + "')", "bt_Download.gif"));
+            "javascript:openDocWindow('" + downloadHref.toUriString() + "')", "bt_Download.gif", "download"));
     }
 
     /**
@@ -207,7 +208,7 @@ public class ListNotesTable {
         }
 
         container.of(LCTableUtil.actionLink(actionId("print"), resword.getString("print"),
-            "javascript:openDocWindow('" + printHref.toUriString() + "')", "bt_Print.gif"));
+            "javascript:openDocWindow('" + printHref.toUriString() + "')", "bt_Print.gif", "print"));
     }
 
     // -- Column definitions --------------------------------------------------------------------------
@@ -350,14 +351,14 @@ public class ListNotesTable {
     /** Renders action links (see class javadoc for intentional legacy parity fix/omission). */
     private void renderActionsCell(Td<?> td, DiscrepancyNoteBean row) {
         String createNoteUrl = CreateDiscrepancyNoteServlet.getAddChildURL(row, ResolutionStatus.CLOSED, true) + "&viewAction=1";
-        td.of(LCTableUtil.actionLink(actionId("view", row), resword.getString("view"), "javascript:openDNWindow('" + createNoteUrl + "');", "bt_View.gif"));
+        td.of(LCTableUtil.actionLink(actionId("view", row), resword.getString("view"), "javascript:openDNWindow('" + createNoteUrl + "');", "bt_View.gif", "view"));
 
         if (!currentStudy.getStatus().isLocked()) {
             // Fixed: the legacy renderer compared getEntityType() != "eventCrf" by reference instead of by value.
             boolean isEventCrf = "eventCrf".equals(row.getEntityType());
             if (!isEventCrf || row.getStageId() == 5) {
                 td.of(LCTableUtil.actionLink(actionId("resolve", row), resword.getString("view_within_crf"),
-                    url("ResolveDiscrepancy").param("noteId", row.getId()), "bt_Reassign.gif"));
+                    url("ResolveDiscrepancy").param("noteId", row.getId()), "bt_Reassign.gif", "resolve"));
             }
         }
 

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTable.java
@@ -147,6 +147,7 @@ public class ListStudySubjectTable {
             .of(div -> {
                 div.label().text("").__();
                 div.select()
+                    .addAttr("data-testid", "select-event-definition")
                     .addAttr("onchange",
                         "var v=this.value; if (v) { window.location='" + ctx.resourcePath
                             + "/ListEventsForSubjects?module=submit&defId=' + v; }")
@@ -164,6 +165,7 @@ public class ListStudySubjectTable {
     /** Toolbar button opening the "Add New Subject" modal. */
     private void renderAddNewSubjectControl(Div<?> container, LCTableContext<FindSubjectsRow> ctx) {
         container.a().attrClass("text-btn").attrHref("javascript:;").attrId("addSubject")
+            .addAttr("data-testid", "add-subject-button")
             .text(resword.getString("add_new_subject"))
             .__();
     }

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTable.java
@@ -122,7 +122,8 @@ public class ListStudySubjectTable {
             this.studyEventDefinitions = studyEventDefinitionDAO.findAllActiveByParentStudyId(studyBean.getId());
         }
 
-        this.table = new LCTable<>("findSubjects", buildColumns(), this::fetchData);
+        this.table = new LCTable<>("findSubjects", buildColumns(), this::fetchData)
+            .setRowTestAttributes(row -> Map.of("subject", row.studySubject.getLabel()));
         this.table.addCustomToolbarControl(this::renderSelectEventControl);
         if (isAddSubjectLinkShown()) {
             this.table.addCustomToolbarControl(this::renderAddNewSubjectControl);
@@ -198,13 +199,16 @@ public class ListStudySubjectTable {
         for (StudyEventDefinitionBean sed : studyEventDefinitions) {
             LCPopup<EventStatusPopup.Context, EventStatusPopup.EventOccurrence> eventPopup =
                 EventStatusPopup.aggregate(sed, studyBean, currentRole, currentUser, resword, resformat);
-            columns.add(customTdCol("sed_" + sed.getId(), sed.getName(), 5, NOT_SORTABLE,
+            LCTableColumnDef<FindSubjectsRow> eventColumn = LCTableColumnDef.<FindSubjectsRow>customTdCol(
+                "sed_" + sed.getId(), sed.getName(), 5, NOT_SORTABLE,
                 // SubjectEventStatus.getName() (Term.getName()) already resolves the translated display name via
                 // the terms resource bundle -- do NOT re-translate it here (that would look up the translated text
                 // itself as if it were a resource key, throwing MissingResourceException).
                 new LCTableFilterDef.Select<>(SubjectEventStatus.toArrayList(), SubjectEventStatus::getName, SubjectEventStatus::getName),
                 LCTablePopupColumn.single(eventPopup, row -> toEventStatusPopupContext(row, sed))
-            ));
+            );
+            eventColumn.setTestAttributes(row -> Map.of("event", sed.getName()));
+            columns.add(eventColumn);
         }
 
         columns.add(customTdCol("actions", resword.getString("rule_actions"), 0, NOT_SORTABLE, LCTableFilterDef.clearFilter(), this::renderActionsCell));
@@ -227,7 +231,7 @@ public class ListStudySubjectTable {
         if (studySubject.getId() == 0) {
             return;
         }
-        td.of(actionLink(actionId("view", studySubject.getId()), resword.getString("view"), url("ViewStudySubject").param("id", studySubject.getId()), "bt_View.gif"));
+        td.of(actionLink(actionId("view", studySubject.getId()), resword.getString("view"), url("ViewStudySubject").param("id", studySubject.getId()), "bt_View.gif", "view"));
 
         if (currentRole.getRole() == Role.MONITOR) {
             return;
@@ -239,25 +243,25 @@ public class ListStudySubjectTable {
         if (studyAvailable && !subjectDeleted && currentRole.getRole() != Role.RESEARCHASSISTANT && currentRole.getRole() != Role.RESEARCHASSISTANT2) {
             td.of(actionLink(actionId("remove", studySubject.getId()), resword.getString("remove"),
                 url("RemoveStudySubject").param("action", "confirm").param("id", studySubject.getId()).param("subjectId", studySubject.getSubjectId()).param("studyId", studySubject.getStudyId()),
-                "bt_Remove.gif"));
+                "bt_Remove.gif", "remove"));
         }
         if (studyAvailable && subjectDeleted) {
             td.of(actionLink(actionId("restore", studySubject.getId()), resword.getString("restore"),
                 url("RestoreStudySubject").param("action", "confirm").param("id", studySubject.getId()).param("subjectId", studySubject.getSubjectId()).param("studyId", studySubject.getStudyId()),
-                "bt_Restore.gif"));
+                "bt_Restore.gif", "restore"));
         }
         if (studyAvailable && currentRole.getRole() != Role.RESEARCHASSISTANT && currentRole.getRole() != Role.RESEARCHASSISTANT2
             && currentRole.getRole() != Role.INVESTIGATOR && studySubject.getStatus() == Status.AVAILABLE) {
-            td.of(actionLink(actionId("reassign", studySubject.getId()), resword.getString("reassign"), url("ReassignStudySubject").param("id", studySubject.getId()), "bt_Reassign.gif"));
+            td.of(actionLink(actionId("reassign", studySubject.getId()), resword.getString("reassign"), url("ReassignStudySubject").param("id", studySubject.getId()), "bt_Reassign.gif", "reassign"));
         }
         if (currentRole.getRole() == Role.INVESTIGATOR && studyAvailable && studySubject.getStatus() != Status.DELETED && row.isSignable) {
-            td.of(actionLink(actionId("sign", studySubject.getId()), resword.getString("sign"), url("SignStudySubject").param("id", studySubject.getId()), "icon_Signed.gif"));
+            td.of(actionLink(actionId("sign", studySubject.getId()), resword.getString("sign"), url("SignStudySubject").param("id", studySubject.getId()), "icon_Signed.gif", "sign"));
         }
         try {
             if (studyAvailable && (currentRole.getRole() == Role.RESEARCHASSISTANT || currentRole.getRole() == Role.RESEARCHASSISTANT2)
                 && studySubject.getStatus() == Status.AVAILABLE && "ACTIVE".equalsIgnoreCase(pManageStatus(studySubject))
                 && "enabled".equalsIgnoreCase(participateStatus(studySubject))) {
-                td.of(actionLink(actionId("connect-participant", studySubject.getId()), resword.getString("connect_participant"), participateUrl(studySubject), "bt_Ocui.gif"));
+                td.of(actionLink(actionId("connect-participant", studySubject.getId()), resword.getString("connect_participant"), participateUrl(studySubject), "bt_Ocui.gif", "connect-participant"));
             }
         } catch (Exception e) {
             // matches legacy behaviour: silently omit the "connect participant" link on any failure

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCPopup.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCPopup.java
@@ -85,17 +85,21 @@ public class LCPopup<T, I> {
     public <C extends Element<C, Z> & FlowContent<C, Z>, Z extends Element> void render(C container, T data) {
         List<I> items = itemsExtractor.apply(data);
         container.div().attrClass(triggerClass.isEmpty() ? "lc-popup-trigger" : triggerClass + " lc-popup-trigger").addAttr("tabindex", "0")
+            .addAttr("data-testid", "lc-popup-trigger")
             .of(trigger -> {
                 triggerRenderer.accept(trigger, items);
                 trigger.div().attrClass("lc-popup " + popupModifierClass)
+                    .addAttr("data-testid", "lc-popup")
                     .of(popup -> {
                         popup.div().attrClass("lc-popup-header table_header_row_left")
+                            .addAttr("data-testid", "lc-popup-header")
                             .of(header -> {
                                 headerRenderer.accept(header, data);
                                 extraHeaderControl.ifPresent(control -> control.accept(header, data));
                             })
                             .__();
                         popup.div().attrClass("lc-popup-body")
+                            .addAttr("data-testid", "lc-popup-body")
                             .of(body -> {
                                 int total = items.size();
                                 for (int i = 0; i < total; i++) {
@@ -111,7 +115,9 @@ public class LCPopup<T, I> {
 
     private void renderItemRow(Div<?> body, T context, I item, int index, int total) {
         boolean compact = itemRenderer.layoutFor(context, item) == PopupItemLayout.COMPACT;
-        body.div().attrClass(compact ? "lc-popup-occurrence-row lc-popup-occurrence-row-compact" : "lc-popup-occurrence-row")
+        body.div().attrClass(compact ? "lc-popup-item lc-popup-item-compact" : "lc-popup-item")
+            .addAttr("data-testid", "lc-popup-item")
+            .addAttr("data-test-index", String.valueOf(index + 1))
             .of(row -> {
                 itemRenderer.renderStatus(row, context, item, index, total);
                 // generic layout chrome owned by LCPopup itself: separates the status content above from the
@@ -123,7 +129,7 @@ public class LCPopup<T, I> {
                             actions.text("Actions: ");   // generic layout chrome owned by LCPopup itself; i18n deferred (see LCTable)
                         }
                         for (PopupAction action : itemRenderer.actionsFor(context, item)) {
-                            actions.of(actionLink(action.elementId, action.label, action.href, action.iconImage, action.showLabel));
+                            actions.of(actionLink(action.elementId, action.label, action.href, action.iconImage, action.showLabel, action.actionName));
                         }
                     })
                     .__();
@@ -201,26 +207,29 @@ public class LCPopup<T, I> {
         public final String iconImage;
         /** if true, renders icon + visible text label; if false, icon-only (with a tooltip, see {@code LCTableUtil.actionLink}). */
         public final boolean showLabel;
+        /** Stable, locale-independent action name used by automated tests. */
+        public final String actionName;
 
-        private PopupAction(String elementId, String label, String href, String iconImage, boolean showLabel) {
+        private PopupAction(String elementId, String label, String href, String iconImage, boolean showLabel, String actionName) {
             this.elementId = elementId;
             this.label = label;
             this.href = href;
             this.iconImage = iconImage;
             this.showLabel = showLabel;
+            this.actionName = actionName;
         }
 
         /** Builds a {@code PopupAction} from a {@link SafeUrl} (the common case). */
-        public static PopupAction of(String elementId, String label, SafeUrl href, String iconImage, boolean showLabel) {
-            return new PopupAction(elementId, label, href.toUriString(), iconImage, showLabel);
+        public static PopupAction of(String elementId, String label, SafeUrl href, String iconImage, boolean showLabel, String actionName) {
+            return new PopupAction(elementId, label, href.toUriString(), iconImage, showLabel, actionName);
         }
 
         /**
          * Builds a {@code PopupAction} from an already-built, pre-encoded href string (e.g. the REST "print" links,
          * whose path segments must not be re-encoded by {@link SafeUrl}).
          */
-        public static PopupAction ofRawHref(String elementId, String label, String href, String iconImage, boolean showLabel) {
-            return new PopupAction(elementId, label, href, iconImage, showLabel);
+        public static PopupAction ofRawHref(String elementId, String label, String href, String iconImage, boolean showLabel, String actionName) {
+            return new PopupAction(elementId, label, href, iconImage, showLabel, actionName);
         }
     }
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
@@ -190,6 +190,9 @@ public class LCTable<T>  {
             Th<?> th = tr.th();
             if (widthStyle != null) th.attrStyle(widthStyle);
             th.a().attrId(tableName + "-sortable-header-" + col.columnName).attrClass("sort-header-link")
+                .addAttr("data-testid", "sort-header")
+                .addAttr("data-test-column", col.columnName)
+                .addAttr("data-test-sort", currentSortDir == null ? "none" : currentSortDir)    // <-- exposes current state for testing
                 .attrHref(href).of(hxGetAttrs(href, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
                 .of(a -> {
                     a.span().attrClass("sort-header-text").text(col.columnDisplayName).__();
@@ -208,7 +211,8 @@ public class LCTable<T>  {
     }
 
     private void renderToolbar(Tr<?> tr, LCTableContext<T> ctx) {
-        tr.td().attrClass("toolbar").attrColspan((int) renderedColumnCount(ctx))
+        tr.td().attrClass("toolbar")
+            .attrColspan((int) renderedColumnCount(ctx))
             .div().attrClass("toolbar-container")
             .of(container -> {
                 // Left: page navigation
@@ -223,6 +227,8 @@ public class LCTable<T>  {
                     final String toggleHref = urlForShowHiddenColsToggle(ctx);
                     container.a().attrClass("text-btn")
                         .attrHref(toggleHref)
+                        .addAttr("data-testid", "toggle-hidden-columns-button")
+                        .addAttr("data-test-action", ctx.showHiddenCols ? "hide" : "show-more")
                         .of(hxGetAttrs(toggleHref, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
                         .text(ctx.showHiddenCols ? "Hide" : "Show More")
                         .__();
@@ -252,14 +258,14 @@ public class LCTable<T>  {
     }
 
     private void renderTableHeader(Thead<?> thead, LCTableContext<T> ctx) {
-        thead.tr().attrClass("header").of(tr -> renderToolbar(tr, ctx)).__();
-        thead.tr().attrClass("header").of(tr -> renderColumnNames(tr, ctx)).__();
-        thead.tr().attrClass("filter").of(tr -> renderFilters(tr, ctx)).__();
+        thead.tr().attrClass("header").addAttr("data-testid", "lctable-toolbar").of(tr -> renderToolbar(tr, ctx)).__();
+        thead.tr().attrClass("header").addAttr("data-testid", "lctable-column-header-row").of(tr -> renderColumnNames(tr, ctx)).__();
+        thead.tr().attrClass("filter").addAttr("data-testid", "lctable-column-filter-row").of(tr -> renderFilters(tr, ctx)).__();
     }
 
     private void renderTableBody(Tbody<?> tbody, LCTableContext<T> ctx) {
         List<T> data = ctx.data.pageItems;
-        tbody.attrClass("tbody");
+        tbody.attrClass("tbody").addAttr("data-testid", "lctable-data");
         IntStream.range(0, data.size()).forEach(i -> {
             T item = data.get(i);
             String rowClass = ((i+1) % 2 == 0) ? "even" : "odd";    // use (i+1) to start from 1 for class assignment
@@ -280,7 +286,7 @@ public class LCTable<T>  {
     private String renderTableHtml(LCTableContext<T> ctx) {
         final StringWriter sw = new StringWriter();
         HtmlFlow.doc(sw)
-            .div().attrId(panelId).attrClass("lctable")
+            .div().attrId(panelId).attrClass("lctable").addAttr("data-testid", "lctable-panel")
             .addAttr("hx-ext", "morph")         // use 'idiomorph' extension for morphing the table content instead of replacing it
             .form().attrId(panelId + "-form")
             // Render sticky parameters first, keeping them at the start of URLs and DOM (form) serialization order.
@@ -307,7 +313,7 @@ public class LCTable<T>  {
                     form.input().attrType(EnumTypeInputType.HIDDEN).attrName(PARAM_SHOW_HIDDEN_COLS).attrValue("true").__();
                 }
             })
-            .table().attrId(panelId + "-table").attrClass("table").attrStyle("border-collapse:collapse")
+            .table().attrId(panelId + "-table").attrClass("table").addAttr("data-testid", "lctable-table").attrStyle("border-collapse:collapse")
             .thead().attrId(panelId + "-thead").of(thead -> renderTableHeader(thead, ctx)).__() // thead
             .tbody().attrId(panelId + "-tbody").attrClass("tbody").of(tbody -> renderTableBody(tbody, ctx)).__() // tbody
             .tfoot().attrId(panelId + "-tfoot").of(tfoot -> renderTableFooter(tfoot, ctx)).__()
@@ -337,7 +343,7 @@ public class LCTable<T>  {
         long    from     = (long) ctx.page * ctx.maxRows + 1;
         long    to       = (long) ctx.page * ctx.maxRows + ctx.data.pageItems.size();
 
-        Tfoot<?> footer = tfoot.attrClass("statusBar");
+        Tfoot<?> footer = tfoot.attrClass("statusBar").addAttr("data-testid", "lctable-status-bar");
         Td<?> td = footer.tr().td().attrColspan((int) renderedColumnCount(ctx));
         final int count = ctx.data.totalCountWithFilter;
         td.text(count == 0 ? "No results." : format("Results %d-%d of %d.", from, to, count)).__();
@@ -356,9 +362,9 @@ public class LCTable<T>  {
         nav.attrClass("toolbar");
 
         // « first
-        pageBtn(nav, "«", url(ctx.entityPath, 0, size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page == 0, tableName + "-nav-btn-first-page");
+        pageBtn(nav, "«", url(ctx.entityPath, 0, size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page == 0, tableName + "-nav-btn-first-page", "first-page");
         // ‹ previous
-        pageBtn(nav, "‹", url(ctx.entityPath, max(0, page - 1), size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page == 0, tableName + "-nav-btn-prev-page");
+        pageBtn(nav, "‹", url(ctx.entityPath, max(0, page - 1), size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page == 0, tableName + "-nav-btn-prev-page", "prev-page");
         // numbered slots / ellipsis
         for (LCTablePageSlot slot : ctx.slots) {
             if (slot.ellipsis()) {
@@ -367,22 +373,27 @@ public class LCTable<T>  {
                 String slotHref = url(ctx.entityPath, slot.page(), size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams);
                 nav.a().attrId(tableName + "-nav-btn-page-" + (slot.page() + 1))
                     .attrClass("text-btn" + (slot.current() ? " current" : ""))
+                    .addAttr("data-testid", "page-button")
+                    .addAttr("data-test-action", "page")
+                    .addAttr("data-test-page", String.valueOf(slot.page() + 1))
                     .attrHref(slotHref).of(hxGetAttrs(slotHref, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
                     .text(String.valueOf(slot.page() + 1))
                     .__(); // a
             }
         }
         // › next
-        pageBtn(nav, "›", url(ctx.entityPath, min(total - 1, page + 1), size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page >= total - 1, tableName + "-nav-btn-next-page");
+        pageBtn(nav, "›", url(ctx.entityPath, min(total - 1, page + 1), size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page >= total - 1, tableName + "-nav-btn-next-page", "next-page");
         // » last
-        pageBtn(nav, "»", url(ctx.entityPath, total - 1, size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page >= total - 1, tableName + "-nav-btn-last-page");
+        pageBtn(nav, "»", url(ctx.entityPath, total - 1, size, sort, dir, ctx.filters, ctx.showHiddenCols, ctx.stickyParams), panelId, page >= total - 1, tableName + "-nav-btn-last-page", "last-page");
 
         nav.__(); // nav.pagination
     }
 
     /** Writes a single pagination button into the given {@code nav} element. */
-    private void pageBtn(Nav<?> nav, String text, String href, String panelId, boolean disabled, String id) {
+    private void pageBtn(Nav<?> nav, String text, String href, String panelId, boolean disabled, String id, String testAction) {
         nav.a().attrId(id).attrClass("text-btn" + (disabled ? " disabled" : ""))
+            .addAttr("data-testid", "page-button")
+            .addAttr("data-test-action", testAction)
             .attrHref(href).of(hxGetAttrs(href, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
             .text(text)
             .__(); // a
@@ -395,6 +406,7 @@ public class LCTable<T>  {
         div.select()
             .attrId(tableName + "-select-max-rows")
             .attrName(PARAM_MAX_ROWS)
+            .addAttr("data-testid", "select-max-rows")
             // Uses "closest form" to submit maxRows along with all other table-state fields.
             .of(hxGetAttrs(ctx.entityPath, "closest form", "#" + panelId, "change"))
             .of(select -> {

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
@@ -45,6 +45,7 @@ public class LCTable<T>  {
     final String panelId;       // ID of the panel element to target with HTMX requests (e.g. "books-panel")
     final List<LCTableColumnDef<T>> columns;
     final Function<LCTableParams, LCTableData<T>> fetchData;
+    private Function<T, Map<String, String>> rowTestAttributes = row -> Collections.emptyMap();
 
     /**
      * Explicit whitelist of "sticky" request parameters (e.g. {@code defId}) that are not related
@@ -98,6 +99,11 @@ public class LCTable<T>  {
         return tableName;
     }
     public List<String> getStickyParamNames() { return stickyParamNames; }
+
+    public LCTable<T> setRowTestAttributes(Function<T, Map<String, String>> rowTestAttributes) {
+        this.rowTestAttributes = Objects.requireNonNull(rowTestAttributes, "rowTestAttributes");
+        return this;
+    }
 
     public List<String> getColumnNames() {
         return columns.stream().map(col -> col.columnName).collect(Collectors.toList());
@@ -257,7 +263,7 @@ public class LCTable<T>  {
         IntStream.range(0, data.size()).forEach(i -> {
             T item = data.get(i);
             String rowClass = ((i+1) % 2 == 0) ? "even" : "odd";    // use (i+1) to start from 1 for class assignment
-            Tr<?> tr = tbody.tr().attrClass(rowClass);
+            Tr<?> tr = tbody.tr().attrClass(rowClass).of(testAttrs(rowTestAttributes.apply(item)));
             columns.forEach(col -> {
                 if (shouldRenderColumn(col, ctx)) col.cellRenderer.accept(tr, item);
             });

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
@@ -14,7 +14,10 @@ import org.xmlet.htmlapifaster.Td;
 import org.xmlet.htmlapifaster.TextGroup;
 import org.xmlet.htmlapifaster.Tr;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -69,7 +72,9 @@ public class LCTableColumnDef<T> {
     public final LCTableFilterDef filterDef;                // null if no filter is foreseen for this column
 
     /** Closure that writes the cell content for a given row bean into the HtmlFlow row element. */
-    public final BiConsumer<Tr<?>, T> cellRenderer;
+    public BiConsumer<Tr<?>, T> cellRenderer;
+
+    private Function<T, Map<String, String>> testAttributes = row -> Collections.emptyMap();
 
     // General constructor
     public LCTableColumnDef(String columnName, String columnDisplayName, double columnWidth, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
@@ -89,6 +94,11 @@ public class LCTableColumnDef<T> {
     }
     public boolean isFilterable() { return this.filterDef != null; }
 
+    public LCTableColumnDef<T> setTestAttributes(Function<T, Map<String, String>> testAttributes) {
+        this.testAttributes = Objects.requireNonNull(testAttributes, "testAttributes");
+        return this;
+    }
+
     // Basic factory method
     public static <T> LCTableColumnDef<T> columnDef(String columnName, String displayName, double columnWidth, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
         return new LCTableColumnDef<>(columnName, displayName, columnWidth, visibility, sortability, filterDef, cellRenderer);
@@ -100,14 +110,16 @@ public class LCTableColumnDef<T> {
      * Evaluates the Optional pipeline, safely rendering the value or a fallback '—'.
      */
     private static <T, V> BiConsumer<Tr<?>, T> nullSafeCell(
-        String columnName,
+        LCTableColumnDef<T> col,
         Function<Optional<T>, Optional<V>> pipeline,
         BiConsumer<Td<?>, V> finish
     ) {
         return (tr, row) -> {
             Td<?> td = tr.td();
-            if (columnName != null) td.attrClass("lc-col-" + columnName);
-            pipeline.apply(Optional.ofNullable(row)).ifPresentOrElse(
+            if (col.columnName != null) td.attrClass("lc-col-" + col.columnName);
+            Optional<T> rowOpt = Optional.ofNullable(row);
+            rowOpt.ifPresent(value -> td.of(LCTableUtil.testAttrs(col.testAttributes.apply(value))));
+            pipeline.apply(rowOpt).ifPresentOrElse(
                 val -> finish.accept(td, val),
                 () -> td.text(NULL_PLACEHOLDER)
             );
@@ -117,82 +129,95 @@ public class LCTableColumnDef<T> {
 
     // --- 2. Null-safe text renderers ---
 
-    private static <T> BiConsumer<Tr<?>, T> nullSafeColText(String columnName, Function<T, String> renderer) {
-        return nullSafeCell(columnName, row -> row.map(renderer), TextGroup::text);
+    private static <T, V> LCTableColumnDef<T> nullSafeColumn(String columnName, String displayName, double width,
+            Visibility visibility, Sortability sortability, LCTableFilterDef filterDef,
+            Function<Optional<T>, Optional<V>> pipeline, BiConsumer<Td<?>, V> finish) {
+        LCTableColumnDef<T> col = new LCTableColumnDef<>(columnName, displayName, width, visibility, sortability, filterDef, null);
+        col.cellRenderer = nullSafeCell(col, pipeline, finish);
+        return col;
     }
 
-    private static <T, F> BiConsumer<Tr<?>, T> nullSafeColText(String columnName, Function<T, F> extractor, Function<F, String> renderer) {
-        return nullSafeCell(columnName, row -> row.map(extractor).map(renderer), TextGroup::text);
+    private static <T> LCTableColumnDef<T> nullSafeTextColumn(String columnName, String displayName, double width,
+            Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, Function<T, String> renderer) {
+        return nullSafeColumn(columnName, displayName, width, visibility, sortability, filterDef,
+            row -> row.map(renderer), TextGroup::text);
+    }
+
+    private static <T, F> LCTableColumnDef<T> nullSafeTextColumn(String columnName, String displayName, double width,
+            Visibility visibility, Sortability sortability, LCTableFilterDef filterDef,
+            Function<T, F> extractor, Function<F, String> renderer) {
+        return nullSafeColumn(columnName, displayName, width, visibility, sortability, filterDef,
+            row -> row.map(extractor).map(renderer), TextGroup::text);
     }
 
     // --- 3. Column factory methods for text columns ---
 
     public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Function<T, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(columnName, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Text(), renderer);
     }
 
     public static <T> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, Function<T, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(columnName, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Text(), renderer);
 
     }
     public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, filterDef, nullSafeColText(columnName, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, filterDef, renderer);
     }
 
     public static <T> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, filterDef, nullSafeColText(columnName, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, filterDef, renderer);
     }
 
     public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Function<T, F> extractor, Function<F, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(columnName, extractor, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Text(), extractor, renderer);
     }
 
     public static <T, F> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, Function<T, F> extractor, Function<F, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Text(), nullSafeColText(columnName, extractor, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Text(), extractor, renderer);
     }
 
     public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, filterDef, nullSafeColText(columnName, extractor, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, filterDef, extractor, renderer);
     }
 
     public static <T, F> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, filterDef, nullSafeColText(columnName, extractor, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, filterDef, extractor, renderer);
     }
 
     // --- 4. Column factory methods for enum-like types (similar to textCol, but with list of allowed value and 'select' filter ---
 
     public static <T, V> LCTableColumnDef<T> enumCol(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(columnName, colRenderer));
+        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
     }
 
     public static <T, V> LCTableColumnDef<T> enumColHidden(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(columnName, colRenderer));
+        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
     }
 
     public static <T, V> LCTableColumnDef<T> enumColNotSortable(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(columnName, colRenderer));
+        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
     }
 
     public static <T, V> LCTableColumnDef<T> enumColHiddenNotSortable(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), nullSafeColText(columnName, colRenderer));
+        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
     }
 
     public static <T, V> LCTableColumnDef<T> enumCol(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(columnName, extractor, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
     }
 
     public static <T, V> LCTableColumnDef<T> enumColHidden(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return new LCTableColumnDef<>(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(columnName, extractor, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
     }
 
     public static <T, V> LCTableColumnDef<T> enumColNotSortable(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), nullSafeColText(columnName, extractor, renderer));
+        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
     }
 
     // --- 5. Column factory methods for custom 'td' rendering ---
 
     public static <T> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Td<?>, T> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, sortability, filterDef, nullSafeCell(columnName, Function.identity(), renderer));
+        return nullSafeColumn(columnName, displayName, width, VISIBLE, sortability, filterDef, Function.identity(), renderer);
     }
 
     /**
@@ -205,8 +230,8 @@ public class LCTableColumnDef<T> {
      * @param renderer    renders the cell's content for a given row (only called if {@code presenceKey.apply(row) != null})
      */
     public static <T, F> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> presenceKey, BiConsumer<Td<?>, T> renderer) {
-        return new LCTableColumnDef<>(columnName, displayName, width, VISIBLE, sortability, filterDef,
-            nullSafeCell(columnName, row -> row.filter(r -> presenceKey.apply(r) != null), renderer));
+        return nullSafeColumn(columnName, displayName, width, VISIBLE, sortability, filterDef,
+            row -> row.filter(r -> presenceKey.apply(r) != null), renderer);
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableFilterDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableFilterDef.java
@@ -72,6 +72,8 @@ public abstract class LCTableFilterDef {
                     .attrName(filterName)
                     .attrValue(filterValue)
                     .attrClass("filter-input")
+                    .addAttr("data-testid", "filter-input")
+                    .addAttr("data-test-column", col.columnName)
                     .attrSize(1L)
                     .attrId(table.tableName + "-text-filter-" + col.columnName);
 
@@ -157,6 +159,8 @@ public abstract class LCTableFilterDef {
                     .attrName(filterName)
                     .attrId(table.tableName + "-select-filter-" + col.columnName)
                     .attrClass("filter-select")
+                    .addAttr("data-testid", "filter-select")
+                    .addAttr("data-test-column", col.columnName)
                     .attrStyle("width:1px;flex:1")
                     .of(hxGetAttrs(ctx.entityPath, "closest form", "#" + table.panelId, "change"));
 
@@ -196,6 +200,8 @@ public abstract class LCTableFilterDef {
             tr.td().a()
                 .attrId(table.tableName + "-clear-filter-" + col.columnName)
                 .attrClass("text-btn")
+                .addAttr("data-testid", "clear-filter-button")
+                .addAttr("data-test-column", col.columnName)     // this refers to the column where the button appears, but the button clears all filters, not just that column
                 .of(hxGetAttrs(ctx.entityPath, selector.toString(), "#" + table.panelId, "click"))
                 .text("Clear Filter")
                 .__().__();

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
@@ -18,6 +18,7 @@ import org.xmlet.htmlapifaster.FlowContent;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public class LCTableUtil {
@@ -84,6 +85,19 @@ public class LCTableUtil {
             .replace("_", "\\_");
     }
 
+    /** Applies non-empty values as {@code data-test-*} attributes to an HtmlFlow element. */
+    public static <T extends CustomAttributeGroup<T, ?>> Consumer<T> testAttrs(Map<String, String> attributes) {
+        return element -> {
+            if (attributes != null && !attributes.isEmpty()) {
+                attributes.forEach((key, value) -> {
+                    if (value != null && !value.isEmpty()) {
+                        element.addAttr("data-test-" + key, value);
+                    }
+                });
+            }
+        };
+    }
+
     // --- generate HTML for various common elements ---
     /**
      * Constructs an action link, optionally with a text label if {@code includeText} is true. If {@code includeText} is false, uses
@@ -95,29 +109,34 @@ public class LCTableUtil {
      * @param href        href for the anchor
      * @param imgSrc      src (relative to "images/") for the inner img
      * @param includeText if true, renders {@code altText} as a visible label; if false, icon-only with a tooltip
+     * @param testAction  stable, locale-independent action name used by automated tests
      */
     public static <T extends Element<T, Z> & FlowContent<T, Z>, Z extends Element> Consumer<T> actionLink(
-            String id, String altText, SafeUrl href, String imgSrc, boolean includeText) {
-        return actionLink(id, altText, href.toUriString(), imgSrc, includeText);
+            String id, String altText, SafeUrl href, String imgSrc, boolean includeText, String testAction) {
+        return actionLink(id, altText, href.toUriString(), imgSrc, includeText, testAction);
     }
 
-    /** Icon-only variant of {@link #actionLink(String, String, SafeUrl, String, boolean)} (no visible text label). */
+    /** Icon-only variant of {@link #actionLink(String, String, SafeUrl, String, boolean, String)} (no visible text label). */
     public static <T extends Element<T, Z> & FlowContent<T, Z>, Z extends Element> Consumer<T> actionLink(
-            String id, String altText, SafeUrl href, String imgSrc) {
-        return actionLink(id, altText, href, imgSrc, false);
+            String id, String altText, SafeUrl href, String imgSrc, String testAction) {
+        return actionLink(id, altText, href, imgSrc, false, testAction);
     }
 
     /**
-     * Same as {@link #actionLink(String, String, SafeUrl, String, boolean)}, but for the rare cases (e.g. the REST
+    * Same as {@link #actionLink(String, String, SafeUrl, String, boolean, String)}, but for the rare cases (e.g. the REST
      * "print" links) where the href is already a fully-built, pre-encoded string rather than a {@link SafeUrl}
      * (re-encoding it via {@code SafeUrl} would corrupt already-percent-encoded path segments).
      */
     public static <T extends Element<T, Z> & FlowContent<T, Z>, Z extends Element> Consumer<T> actionLink(
-            String id, String altText, String href, String imgSrc, boolean includeText) {
+            String id, String altText, String href, String imgSrc, boolean includeText, String testAction) {
         return container -> {
             var anchor = container.a().attrClass("action-link").attrHref(href).addAttr("aria-label", altText);
             if (id != null) {
                 anchor = anchor.attrId(id);
+            }
+            if (testAction != null) {
+                anchor = anchor.addAttr("data-testid", "action-link")
+                    .addAttr("data-test-action", testAction);
             }
             if (!includeText) {
                 anchor = anchor.addAttr("data-tooltip", altText);
@@ -130,10 +149,10 @@ public class LCTableUtil {
         };
     }
 
-    /** Icon-only variant of {@link #actionLink(String, String, String, String, boolean)} (no visible text label). */
+    /** Icon-only variant of {@link #actionLink(String, String, String, String, boolean, String)} (no visible text label). */
     public static <T extends Element<T, Z> & FlowContent<T, Z>, Z extends Element> Consumer<T> actionLink(
-            String id, String altText, String href, String imgSrc) {
-        return actionLink(id, altText, href, imgSrc, false);
+            String id, String altText, String href, String imgSrc, String testAction) {
+        return actionLink(id, altText, href, imgSrc, false, testAction);
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
@@ -12,6 +12,7 @@ package org.akaza.openclinica.lctable;
 
 import static org.akaza.openclinica.lctable.LCTable.*;
 
+import com.google.common.html.HtmlEscapers;
 import org.xmlet.htmlapifaster.CustomAttributeGroup;
 import org.xmlet.htmlapifaster.Element;
 import org.xmlet.htmlapifaster.FlowContent;
@@ -91,7 +92,8 @@ public class LCTableUtil {
             if (attributes != null && !attributes.isEmpty()) {
                 attributes.forEach((key, value) -> {
                     if (value != null && !value.isEmpty()) {
-                        element.addAttr("data-test-" + key, value);
+                        String safeValue = HtmlEscapers.htmlEscaper().escape(value);
+                        element.addAttr("data-test-" + key, safeValue);
                     }
                 });
             }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
@@ -12,7 +12,7 @@ package org.akaza.openclinica.lctable;
 
 import static org.akaza.openclinica.lctable.LCTable.*;
 
-import com.google.common.html.HtmlEscapers;
+import org.springframework.web.util.HtmlUtils;
 import org.xmlet.htmlapifaster.CustomAttributeGroup;
 import org.xmlet.htmlapifaster.Element;
 import org.xmlet.htmlapifaster.FlowContent;
@@ -92,7 +92,7 @@ public class LCTableUtil {
             if (attributes != null && !attributes.isEmpty()) {
                 attributes.forEach((key, value) -> {
                     if (value != null && !value.isEmpty()) {
-                        String safeValue = HtmlEscapers.htmlEscaper().escape(value);
+                        String safeValue = HtmlUtils.htmlEscape(value);
                         element.addAttr("data-test-" + key, safeValue);
                     }
                 });

--- a/web/src/main/webapp/includes/lctable/lctable.css
+++ b/web/src/main/webapp/includes/lctable/lctable.css
@@ -426,13 +426,13 @@
     border-radius: 0;
 }
 
-.lctable .lc-popup-status-badge {
+.lctable .lc-popup-badge {
     display: inline-flex;
     align-items: center;
     margin-right: 6px;
 }
 
-.lctable .lc-popup-status-badge:last-child {
+.lctable .lc-popup-badge:last-child {
     margin-right: 0;
 }
 
@@ -509,23 +509,23 @@
 /*
  * "Hybrid" per-occurrence row layouts (see ListStudySubjectTable#renderPopupBody and friends):
  *  - non-repeating events (and events with no occurrence yet): "simple" layout, one action per line,
- *    each with icon + text label -- ".lc-popup-occurrence-row" without the "-compact" modifier.
+ *    each with icon + text label -- ".lc-popup-item" without the "-compact" modifier.
  *  - repeating events (with at least one occurrence): "compact" layout, two lines per occurrence
  *    ("Occurrence #i of N · date · status" then "Actions: " + icon-only links) --
- *    ".lc-popup-occurrence-row.lc-popup-occurrence-row-compact".
- * In both cases, ".lc-popup-occurrence-row" is the hoverable/highlightable unit (the "row" the user
+ *    ".lc-popup-item.lc-popup-item-compact".
+ * In both cases, ".lc-popup-item" is the hoverable/highlightable unit (the "row" the user
  * points at). A subtle border/box gives each occurrence a permanent, "passive" visual grouping (a bit
  * more pronounced than the thin lines separating the 1-2 lines *within* one occurrence), on top of
  * which hovering adds a slightly darker shade of the popup's pale-yellow background.
  */
-.lctable .lc-popup-occurrence-row {
+.lctable .lc-popup-item {
     margin: 3px 4px;
     padding: 3px 4px;
     border: 1px solid #E0D9A0;
     border-radius: 3px;
 }
 
-.lctable .lc-popup-occurrence-row:hover {
+.lctable .lc-popup-item:hover {
     background-color: #F5EEA0;
     border-color: #C9BC66;
 }
@@ -541,8 +541,8 @@
  * ".lc-popup-row-separator" div, in both EventStatusPopup and CrfStatusPopup -- see their
  * renderSimpleStatus/renderStatus.
  */
-.lctable .lc-popup-occurrence-row .table_cell_left,
-.lctable .lc-popup-occurrence-row .table_cell {
+.lctable .lc-popup-item .table_cell_left,
+.lctable .lc-popup-item .table_cell {
     border: none;
 }
 
@@ -600,8 +600,8 @@
     align-items: center;
 }
 
-.lctable .lc-popup-occurrence-row .lc-popup-actions img,
-.lctable .lc-popup-occurrence-row .lc-popup-summary-line img {
+.lctable .lc-popup-item .lc-popup-actions img,
+.lctable .lc-popup-item .lc-popup-summary-line img {
     vertical-align: middle;
 }
 
@@ -624,7 +624,7 @@
  * the Event Status/Event Date/each CRF column -- see ListEventsForSubjectTable). Scoped with the
  * table's own "#<tableName>-panel" wrapper id (see LCTable#panelId) rather than a shared class, so
  * that none of this affects the "findSubjects" table (#findSubjects-panel), which reuses the very
- * same ".event-trigger"/".lc-popup-status-badge" classes for its own -- horizontal, aggregate-per-cell --
+ * same ".event-trigger"/".lc-popup-badge" classes for its own -- horizontal, aggregate-per-cell --
  * layout (multiple status badges side by side *within* a single trigger, one trigger per cell).
  *
  * Goal: the occurrences' rows in the Event Status, Event Date and CRF columns are meant to line up

--- a/web/src/test/java/org/akaza/openclinica/lctable/LCTableTest.java
+++ b/web/src/test/java/org/akaza/openclinica/lctable/LCTableTest.java
@@ -1,0 +1,108 @@
+/*
+ * LibreClinica is distributed under the GNU Lesser General Public License (GNU LGPL).
+ */
+package org.akaza.openclinica.lctable;
+
+import junit.framework.TestCase;
+import org.akaza.openclinica.lctable.LCPopup.PopupAction;
+import org.akaza.openclinica.lctable.LCPopup.PopupItemLayout;
+import org.akaza.openclinica.lctable.LCPopup.PopupItemRenderer;
+import org.xmlet.htmlapifaster.Div;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.akaza.openclinica.lctable.LCTableColumnDef.NOT_SORTABLE;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.NO_FILTER;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.customTdCol;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.textCol;
+import static org.akaza.openclinica.lctable.SafeUrl.url;
+
+public class LCTableTest extends TestCase {
+
+    public void testRendersRowCellPopupAndActionTestAttributes() {
+        LCPopup<Row, String> popup = new LCPopup<>(
+            row -> List.of("item"),
+            (trigger, items) -> trigger.text("trigger"),
+            (header, row) -> header.text("header"),
+            Optional.empty(),
+            new PopupItemRenderer<>() {
+                @Override
+                public void renderStatus(Div<?> row, Row context, String item, int index, int total) {
+                    row.text(item);
+                }
+
+                @Override
+                public List<PopupAction> actionsFor(Row context, String item) {
+                    return List.of(PopupAction.of(null, "View", url("View"), "bt_View.gif", true, "view"));
+                }
+
+                @Override
+                public PopupItemLayout layoutFor(Row context, String item) {
+                    return PopupItemLayout.SIMPLE;
+                }
+            },
+            "event-trigger",
+            "TestPopup"
+        );
+
+        LCTableColumnDef<Row> popupColumn = customTdCol(
+            "event", "Event", 0, NOT_SORTABLE, NO_FILTER,
+            (td, row) -> popup.render(td, row)
+        );
+        popupColumn.setTestAttributes(row -> Map.of("event", row.event));
+
+        LCTable<Row> table = new LCTable<>(
+            "testTable",
+            List.of(textCol("subject", "Subject", 0, row -> row.subject), popupColumn),
+            params -> new LCTableData<>(List.of(new Row("M-001", "Baseline")), 1)
+        ).setRowTestAttributes(row -> Map.of("subject", row.subject));
+
+        String html = table.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "");
+
+        assertTrue(html.contains("data-test-subject=\"M-001\""));
+        assertTrue(html.contains("data-test-event=\"Baseline\""));
+        assertTrue(html.contains("data-testid=\"lc-popup-trigger\""));
+        assertTrue(html.contains("data-testid=\"lc-popup-header\""));
+        assertTrue(html.contains("data-testid=\"lc-popup-body\""));
+        assertTrue(html.contains("class=\"lc-popup-item\""));
+        assertTrue(html.contains("data-testid=\"lc-popup-item\""));
+        assertTrue(html.contains("data-test-index=\"1\""));
+        assertTrue(html.contains("data-test-action=\"view\""));
+    }
+
+    public void testOmitsNullAndEmptyTestAttributeValues() {
+        LCTableColumnDef<Row> column = textCol("subject", "Subject", 0, row -> row.subject);
+        column.setTestAttributes(row -> {
+            java.util.LinkedHashMap<String, String> attributes = new java.util.LinkedHashMap<>();
+            attributes.put("null-value", null);
+            attributes.put("empty-value", "");
+            attributes.put("subject", row.subject);
+            return attributes;
+        });
+
+        LCTable<Row> table = new LCTable<>(
+            "testTable",
+            List.of(column),
+            params -> new LCTableData<>(List.of(new Row("M-001", "Baseline")), 1)
+        );
+
+        String html = table.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "");
+
+        assertTrue(html.contains("data-test-subject=\"M-001\""));
+        assertFalse(html.contains("data-test-null-value"));
+        assertFalse(html.contains("data-test-empty-value"));
+    }
+
+    private static final class Row {
+        private final String subject;
+        private final String event;
+
+        private Row(String subject, String event) {
+            this.subject = subject;
+            this.event = event;
+        }
+    }
+}


### PR DESCRIPTION
Implementation of `data-testid` and `data-test-*` attributes in the HTML code of LCTable-based data tables, in order to facilitate automated UI testing (E2E testing).

Main features:
* Tagging of rows and cells: rows (`<tr>`) and specific cells (`<td>`) can now be tagged with application-specific labels (e.g., `data-test-subject="M-001"`, `data-test-event="V1"`) allowing testers to easily locate data in the table.
* Component test IDs: important UI structures (especially the complex `LCPopup` elements) now expose `data-testid` attributes to identify them and their components (e.g., `lc-popup-trigger`, `lc-popup-body`, `lc-popup-item`).
* Locale-agnostic actions: "action links", whose `data_testid` is `action-link`, include a `data-test-action` (e.g., `view`, `edit`, `remove`) in order to retrieve the action link without relying on display names and independently of any localisation.
* Popups for repeating events: Popup items (whose `data-testid` is `lc-popup-item`) automatically receive a `data-test-index="1"` (... `="2"`, etc.) attribute to find specific occurrences of repeating events.

(See "Appendix: LCTable UI Testing Guide" in the [LCTable Library User Documentation](https://github.com/reliatec-gmbh/LibreClinica/wiki/LCTable-Library-User-Documentation) for more details and examples).

Summary of changes:

* Core LCTable API (`LCTable.java`, `LCTableColumnDef.java`):
    * Added `setRowTestAttributes` and `setTestAttributes` to set test attributes for a row and a cell, respectively, accepting a `Function<T, Map<String, String>>`. The map specifies the name-value pairs for all test attributes to be included (omitting the `data-test-` prefix from the attribute name).
* HTML generation (`LCTableUtil.java`, `LCPopup.java`):
    * Added the `testAttrs(Map)` utility to convert a test attributes map (see above) into the corresponding HtmlFlow code for generating the attributes (automatically adding the `data-test-` prefix).  
    * Updated `LCPopup` to automatically inject test-IDs for the various popup components (`data-testid="lc-popup-*"`) and occurrence indices (`data-test-index`).
    * Updated `actionLink` builders to accept the action name to be used in `data-test-action` and render`data-testid="action-link"` and the respective `data-test-action` with the given name.
* Popup Implementations (`CrfStatusPopup.java`, `EventStatusPopup.java`):
    * Added all necessary tagging with test attributes.
* Concrete Table Instantiations (`ListStudySubjectTable`, `ListEventsForSubjectTable`, `ListNotesTable`, `AuditUserLoginTable`):
    * Configured the tables to include test attributes with application-specific, meaningful names (e.g., `subject`, `event`, `crf`, `note`, `login`).
    * Updated all action links to include appropriate `data-test-action` attributes.