### PR TITLE
First working implementation of LCTable-based `studyAuditLogs` table.

### DIFF
--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/StudyAuditLogServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/StudyAuditLogServlet.java
@@ -5,7 +5,7 @@
  * For details see: https://libreclinica.org/license
  * copyright (C) 2003 - 2011 Akaza Research
  * copyright (C) 2003 - 2019 OpenClinica
- * copyright (C) 2020 - 2024 LibreClinica
+ * copyright (C) 2020 - 2026 LibreClinica
  */
 package org.akaza.openclinica.control.managestudy;
 

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/StudyAuditLogServlet.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/StudyAuditLogServlet.java
@@ -16,6 +16,7 @@ import org.akaza.openclinica.control.core.SecureController;
 import org.akaza.openclinica.dao.login.UserAccountDAO;
 import org.akaza.openclinica.dao.managestudy.StudySubjectDAO;
 import org.akaza.openclinica.dao.submit.SubjectDAO;
+import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.view.Page;
 import org.akaza.openclinica.web.InsufficientPermissionException;
 
@@ -57,16 +58,34 @@ public class StudyAuditLogServlet extends SecureController {
         SubjectDAO sdao = new SubjectDAO(sm.getDataSource());
         UserAccountDAO uadao = new UserAccountDAO(sm.getDataSource());
 
-        StudyAuditLogTableFactory factory = new StudyAuditLogTableFactory();
-        factory.setSubjectDao(sdao);
-        factory.setStudySubjectDao(subdao);
-        factory.setUserAccountDao(uadao);
-        factory.setCurrentStudy(currentStudy);
+        String lcTableRendering = System.getenv("LC_TABLE_RENDERING");
+        if (lcTableRendering != null && lcTableRendering.equalsIgnoreCase("jmesa")) {
+            request.setAttribute("tableRenderingMode", "jmesa");
+            StudyAuditLogTableFactory factory = new StudyAuditLogTableFactory();
+            factory.setSubjectDao(sdao);
+            factory.setStudySubjectDao(subdao);
+            factory.setUserAccountDao(uadao);
+            factory.setCurrentStudy(currentStudy);
 
-        String auditLogsHtml = factory.createTable(request, response).render();
-        request.setAttribute("auditLogsHtml", auditLogsHtml);
+            String auditLogsHtml = factory.createTable(request, response).render();
+            request.setAttribute("auditLogsHtml", auditLogsHtml);
+            forwardPage(Page.AUDIT_LOGS_STUDY);
+        } else {
+            request.setAttribute("tableRenderingMode", "htmlflow");
+            StudyAuditLogTable table = new StudyAuditLogTable(
+                subdao, sdao, uadao, currentStudy, LocaleResolver.getLocale(request));
+            String auditLogsHtml = table.render(request);
 
-        forwardPage(Page.AUDIT_LOGS_STUDY);
+            response.addHeader("Vary", "HX-Request");
+            if (request.getHeader("HX-Request") != null) {
+                response.setContentType("text/html;charset=UTF-8");
+                response.getWriter().write(auditLogsHtml);
+                response.getWriter().flush();
+            } else {
+                request.setAttribute("auditLogsHtml", auditLogsHtml);
+                forwardPage(Page.AUDIT_LOGS_STUDY);
+            }
+        }
 
     }
 

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTable.java
@@ -1,0 +1,200 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+ *
+ * For details see: https://libreclinica.org/license
+ * copyright (C) 2026 LibreClinica
+ */
+package org.akaza.openclinica.control.managestudy;
+
+import org.akaza.openclinica.bean.core.Status;
+import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.bean.managestudy.StudyBean;
+import org.akaza.openclinica.bean.managestudy.StudySubjectBean;
+import org.akaza.openclinica.bean.submit.SubjectBean;
+import org.akaza.openclinica.dao.login.UserAccountDAO;
+import org.akaza.openclinica.dao.managestudy.StudyAuditLogFilter;
+import org.akaza.openclinica.dao.managestudy.StudyAuditLogSort;
+import org.akaza.openclinica.dao.managestudy.StudySubjectDAO;
+import org.akaza.openclinica.dao.submit.SubjectDAO;
+import org.akaza.openclinica.i18n.util.I18nFormatUtil;
+import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+import org.akaza.openclinica.lctable.LCTable;
+import org.akaza.openclinica.lctable.LCTableColumnDef;
+import org.akaza.openclinica.lctable.LCTableData;
+import org.akaza.openclinica.lctable.LCTableFilterDef;
+import org.akaza.openclinica.lctable.LCTableParams;
+import org.akaza.openclinica.lctable.LCTableUtil;
+import org.akaza.openclinica.lctable.SafeUrl;
+import org.xmlet.htmlapifaster.Td;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static org.akaza.openclinica.lctable.LCTableColumnDef.NOT_SORTABLE;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.SORTABLE;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.VISIBLE;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.customTdCol;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.enumCol;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.textCol;
+import static org.akaza.openclinica.lctable.LCTableFilterDef.clearFilter;
+import static org.akaza.openclinica.lctable.LCTableFilterDef.textFilter;
+import static org.akaza.openclinica.lctable.SafeUrl.url;
+
+/**
+ * LCTable-based study-subject audit-log index served by {@link StudyAuditLogServlet}.
+ *
+ * <p>The legacy DAO filter/sort classes and per-row DAO lookups are intentionally retained so this
+ * migration changes only the table UI. The sole data-ordering change is a deterministic default sort
+ * by study-subject label.</p>
+ */
+public class StudyAuditLogTable {
+
+    private static final String TABLE_NAME = "studyAuditLogs";
+    private static final String DOB_FILTER_PATTERN = "(?:\\d{4}|(?:0[1-9]|[12]\\d|3[01])-[A-Za-z]{3}-\\d{4})";
+
+    private final StudySubjectDAO studySubjectDao;
+    private final SubjectDAO subjectDao;
+    private final UserAccountDAO userAccountDao;
+    private final StudyBean currentStudy;
+    private final Locale locale;
+    private final ResourceBundle resword;
+    private final ResourceBundle resformat;
+    private final LCTable<StudyAuditLogRow> table;
+
+    public StudyAuditLogTable(StudySubjectDAO studySubjectDao, SubjectDAO subjectDao,
+            UserAccountDAO userAccountDao, StudyBean currentStudy, Locale locale) {
+        this.studySubjectDao = studySubjectDao;
+        this.subjectDao = subjectDao;
+        this.userAccountDao = userAccountDao;
+        this.currentStudy = currentStudy;
+        this.locale = locale;
+        this.resword = ResourceBundleProvider.getWordsBundle(locale);
+        this.resformat = ResourceBundleProvider.getFormatBundle(locale);
+        this.table = new LCTable<>(TABLE_NAME, buildColumns(), this::fetchData)
+            .setRowTestAttributes(row -> Map.of("subject", row.studySubject.getLabel()));
+    }
+
+    private static String actionId(String action, StudyAuditLogRow row) {
+        return TABLE_NAME + "-" + action + "-" + row.studySubject.getId();
+    }
+
+    private List<LCTableColumnDef<StudyAuditLogRow>> buildColumns() {
+        List<LCTableColumnDef<StudyAuditLogRow>> columns = new ArrayList<>();
+
+        columns.add(textColWithKey("studySubject.label", "study_subject_ID", SORTABLE,
+            textFilter(), row -> row.studySubject.getLabel()));
+        columns.add(textColWithKey("studySubject.secondaryLabel", "secondary_subject_ID", SORTABLE,
+            textFilter(), row -> row.studySubject.getSecondaryLabel()));
+        columns.add(textColWithKey("studySubject.oid", "study_subject_oid", SORTABLE,
+            textFilter(), row -> row.studySubject.getOid()));
+        columns.add(textColWithKey("subject.dateOfBirth", "date_of_birth", SORTABLE,
+            textFilter(DOB_FILTER_PATTERN, "Please enter a year (yyyy) or date in " + getDateFormat() + " format"),
+            row -> resolveBirthDay(row.subject.getDateOfBirth(), row.subject.isDobCollected())));
+        columns.add(textColWithKey("subject.uniqueIdentifier", "person_ID", SORTABLE,
+            textFilter(), row -> row.subject.getUniqueIdentifier()));
+        LCTableColumnDef<StudyAuditLogRow> ownerColumn = textCol(
+            "studySubject.owner", resword.getString("created_by"), 0, VISIBLE, NOT_SORTABLE,
+            textFilter(), row -> row.owner, UserAccountBean::getName
+        );
+        ownerColumn.setTestAttributes(row -> Map.of("column", "created_by"));
+        columns.add(ownerColumn);
+
+        LCTableColumnDef<StudyAuditLogRow> statusColumn = enumCol(
+            "studySubject.status", resword.getString("status"), 0,
+            row -> row.studySubject.getStatus(), Status.toActiveArrayList(), Status::getName,
+            status -> Integer.toString(status.getId())
+        );
+        statusColumn.setTestAttributes(row -> Map.of("column", "status"));
+        columns.add(statusColumn);
+
+        columns.add(customTdColWithKey("actions", "actions", NOT_SORTABLE, clearFilter(), this::renderActionsCell));
+        return columns;
+    }
+
+    private LCTableColumnDef<StudyAuditLogRow> textColWithKey(String columnName, String resourceKey,
+            LCTableColumnDef.Sortability sortability, LCTableFilterDef filter,
+            Function<StudyAuditLogRow, String> renderer) {
+        return textCol(columnName, resword.getString(resourceKey), 0, VISIBLE, sortability, filter, renderer)
+            .setTestAttributes(row -> Map.of("column", resourceKey));
+    }
+
+    private LCTableColumnDef<StudyAuditLogRow> customTdColWithKey(String columnName, String resourceKey,
+            LCTableColumnDef.Sortability sortability, LCTableFilterDef filter,
+            BiConsumer<Td<?>, StudyAuditLogRow> renderer) {
+        return customTdCol(columnName, resword.getString(resourceKey), 0, sortability, filter, renderer)
+            .setTestAttributes(row -> Map.of("column", resourceKey));
+    }
+
+    private void renderActionsCell(Td<?> td, StudyAuditLogRow row) {
+        SafeUrl href = url("ViewStudySubjectAuditLog").param("id", row.studySubject.getId());
+        td.of(LCTableUtil.actionLink(actionId("view", row), resword.getString("view"),
+            "javascript:openDocWindow('" + href.toUriString() + "')", "bt_View.gif", "view"));
+    }
+
+    private LCTableData<StudyAuditLogRow> fetchData(LCTableParams params) {
+        StudyAuditLogFilter filter = new StudyAuditLogFilter(getDateFormat());
+        params.filters.forEach(filter::addFilter);
+
+        boolean noSort = params.sortProp == null || params.sortProp.isEmpty();
+        StudyAuditLogSort sort = new StudyAuditLogSort();
+        sort.addSort(noSort ? "studySubject.label" : params.sortProp, noSort ? "asc" : params.sortDir);
+
+        int rowStart = params.page * params.maxRows;
+        int rowEnd = rowStart + params.maxRows;
+        Collection<StudySubjectBean> studySubjects = studySubjectDao
+            .getWithFilterAndSort(currentStudy, filter, sort, rowStart, rowEnd);
+
+        List<StudyAuditLogRow> rows = new ArrayList<>();
+        for (StudySubjectBean studySubject : studySubjects) {
+            SubjectBean subject = subjectDao.findByPK(studySubject.getSubjectId());
+            UserAccountBean owner = userAccountDao.findByPK(studySubject.getOwnerId());
+            rows.add(new StudyAuditLogRow(studySubject, subject, owner));
+        }
+
+        int total = studySubjectDao.getCountWithFilter(filter, currentStudy);
+        return new LCTableData<>(rows, total);
+    }
+
+    private String getDateFormat() {
+        return resformat.getString("date_format_string");
+    }
+
+    private String resolveBirthDay(Date birthDate, boolean dobCollected) {
+        if (birthDate == null) {
+            return "";
+        }
+        if (dobCollected) {
+            return I18nFormatUtil.getDateFormat(locale).format(birthDate);
+        }
+        Calendar calendar = Calendar.getInstance(locale);
+        calendar.setTime(birthDate);
+        return Integer.toString(calendar.get(Calendar.YEAR));
+    }
+
+    public String render(HttpServletRequest request) {
+        LCTableParams params = new LCTableParams(request.getQueryString(), table);
+        return table.render(request.getRequestURI(), params, request.getContextPath());
+    }
+
+    private static final class StudyAuditLogRow {
+        private final StudySubjectBean studySubject;
+        private final SubjectBean subject;
+        private final UserAccountBean owner;
+
+        private StudyAuditLogRow(StudySubjectBean studySubject, SubjectBean subject, UserAccountBean owner) {
+            this.studySubject = studySubject;
+            this.subject = subject;
+            this.owner = owner;
+        }
+    }
+}

--- a/web/src/main/webapp/WEB-INF/jsp/admin/studyAuditLog.jsp
+++ b/web/src/main/webapp/WEB-INF/jsp/admin/studyAuditLog.jsp
@@ -11,26 +11,29 @@
 <jsp:include page="../include/sideAlert.jsp"/>
 <%--<jsp:include page="../include/sidebar.jsp"/>--%>
 
-<link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa.js"></script>
-<script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery-migrate-3.4.1.min.js"></script> 
+<c:choose>
+    <c:when test="${tableRenderingMode == 'jmesa'}">
+        <link rel="stylesheet" href="includes/jmesa/jmesa.css" type="text/css">
+    </c:when>
+    <c:otherwise>
+        <link rel="stylesheet" href="includes/lctable/lctable.css" type="text/css">
+    </c:otherwise>
+</c:choose>
+<c:if test="${tableRenderingMode == 'jmesa'}">
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.min.js"></script>
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery.jmesa.js"></script>
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jmesa.js"></script>
+    <script type="text/JavaScript" language="JavaScript" src="includes/jmesa/jquery-migrate-3.4.1.min.js"></script>
 
-
-
-<script type="text/javascript">
-    function onInvokeAction(id,action) {
-        if(id.indexOf('studyAuditLogs') == -1)  {
-        setExportToLimit(id, '');
+    <script type="text/javascript">
+        function onInvokeAction(id,action) {
+            if(id.indexOf('studyAuditLogs') == -1)  {
+                setExportToLimit(id, '');
+            }
+            createHiddenInputFieldsForLimitAndSubmit(id);
         }
-        createHiddenInputFieldsForLimitAndSubmit(id);
-    }
-    function onInvokeExportAction(id) {
-        var parameterString = createParameterStringForLimit(id);
-        location.href = '${pageContext.request.contextPath}/StudyAuditLog?' + parameterString;
-    }
-</script>
+    </script>
+</c:if>
 
 <!-- then instructions-->
 <tr id="sidebar_Instructions_open" style="display: none">
@@ -63,12 +66,20 @@
 <fmt:message key="view_study_log_for" bundle="${resword}"/> <c:out value="${study.name}"/>
 </span></h1>
 
-<div id="findSubjectsDiv">
-    <form  action="${pageContext.request.contextPath}/StudyAuditLog">
-        <input type="hidden" name="module" value="submit">
-        ${auditLogsHtml}
-    </form>
+<div id="studyAuditLogsDiv">
+    <c:choose>
+        <c:when test="${tableRenderingMode == 'jmesa'}">
+            <form action="${pageContext.request.contextPath}/StudyAuditLog">
+                <input type="hidden" name="module" value="submit">
+                ${auditLogsHtml}
+            </form>
+        </c:when>
+        <c:otherwise>
+            ${auditLogsHtml}
+        </c:otherwise>
+    </c:choose>
 </div>
 
+<jsp:include page="../include/useLCTable.jsp"/>
 
 <jsp:include page="../include/footer.jsp"/>

--- a/web/src/test/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTableTest.java
+++ b/web/src/test/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTableTest.java
@@ -1,5 +1,9 @@
 /*
- * LibreClinica is distributed under the GNU Lesser General Public License (GNU LGPL).
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+ *
+ * For details see: https://libreclinica.org/license
+ * copyright (C) 2026 LibreClinica
  */
 package org.akaza.openclinica.control.managestudy;
 

--- a/web/src/test/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTableTest.java
+++ b/web/src/test/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTableTest.java
@@ -1,0 +1,92 @@
+/*
+ * LibreClinica is distributed under the GNU Lesser General Public License (GNU LGPL).
+ */
+package org.akaza.openclinica.control.managestudy;
+
+import junit.framework.TestCase;
+import org.akaza.openclinica.bean.core.Status;
+import org.akaza.openclinica.bean.login.UserAccountBean;
+import org.akaza.openclinica.bean.managestudy.StudyBean;
+import org.akaza.openclinica.bean.managestudy.StudySubjectBean;
+import org.akaza.openclinica.bean.submit.SubjectBean;
+import org.akaza.openclinica.dao.login.UserAccountDAO;
+import org.akaza.openclinica.dao.managestudy.StudyAuditLogFilter;
+import org.akaza.openclinica.dao.managestudy.StudyAuditLogSort;
+import org.akaza.openclinica.dao.managestudy.StudySubjectDAO;
+import org.akaza.openclinica.dao.submit.SubjectDAO;
+import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Locale;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class StudyAuditLogTableTest extends TestCase {
+
+    @Override
+    protected void setUp() {
+        ResourceBundleProvider.updateLocale(Locale.ENGLISH);
+    }
+
+    public void testRendersTypedRowFiltersAndPopupActionWithDefaultSort() {
+        StudySubjectDAO studySubjectDao = mock(StudySubjectDAO.class);
+        SubjectDAO subjectDao = mock(SubjectDAO.class);
+        UserAccountDAO userAccountDao = mock(UserAccountDAO.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        StudyBean study = new StudyBean();
+        UserAccountBean owner = new UserAccountBean();
+        owner.setId(9);
+        owner.setName("owner1");
+
+        StudySubjectBean studySubject = new StudySubjectBean();
+        studySubject.setId(42);
+        studySubject.setLabel("SUB-001");
+        studySubject.setSecondaryLabel("SECONDARY-001");
+        studySubject.setOid("SS_SUB_001");
+        studySubject.setSubjectId(7);
+        studySubject.setOwner(owner);
+        studySubject.setStatus(Status.AVAILABLE);
+
+        SubjectBean subject = new SubjectBean();
+        subject.setUniqueIdentifier("PERSON-001");
+
+        ArrayList<StudySubjectBean> rows = new ArrayList<>();
+        rows.add(studySubject);
+        when(studySubjectDao.getWithFilterAndSort(
+            same(study), any(StudyAuditLogFilter.class), any(StudyAuditLogSort.class), anyInt(), anyInt()
+        )).thenReturn(rows);
+        when(studySubjectDao.getCountWithFilter(any(StudyAuditLogFilter.class), same(study))).thenReturn(1);
+        when(subjectDao.findByPK(7)).thenReturn(subject);
+        when(userAccountDao.findByPK(9)).thenReturn(owner);
+        when(request.getQueryString()).thenReturn(null);
+        when(request.getRequestURI()).thenReturn("/StudyAuditLog");
+        when(request.getContextPath()).thenReturn("");
+
+        String html = new StudyAuditLogTable(
+            studySubjectDao, subjectDao, userAccountDao, study, Locale.ENGLISH
+        ).render(request);
+
+        assertTrue(html.contains("data-test-subject=\"SUB-001\""));
+        assertTrue(html.contains("SECONDARY-001"));
+        assertTrue(html.contains("SS_SUB_001"));
+        assertTrue(html.contains("PERSON-001"));
+        assertTrue(html.contains("owner1"));
+        assertTrue(html.contains("value=\"1\""));
+        assertTrue(html.contains("javascript:openDocWindow"));
+        assertTrue(html.contains("ViewStudySubjectAuditLog?id=42"));
+        assertTrue(html.contains("data-test-action=\"view\""));
+        assertTrue(html.contains("pattern=\"(?:\\d{4}|(?:0[1-9]|[12]\\d|3[01])-[A-Za-z]{3}-\\d{4})\""));
+
+        verify(subjectDao).findByPK(7);
+        verify(userAccountDao).findByPK(9);
+        verify(studySubjectDao).getWithFilterAndSort(
+            same(study), any(StudyAuditLogFilter.class), any(StudyAuditLogSort.class), anyInt(), anyInt()
+        );
+    }
+}


### PR DESCRIPTION
First working implementation of LCTable-based `studyAuditLogs` table replacing the corresponding legacy jmesa table (see https://github.com/reliatec-gmbh/LibreClinica/issues/74).

This is the 5th migrated jmesa table. It is configured by the `StudyAuditLogTable` class (see also https://github.com/reliatec-gmbh/LibreClinica/wiki/jmesa-tables-migration:-progress-and-to-do).

Summary of code changes:
- `StudyAuditLogTable`: new class for configuring the `studyAuditLogs` table
- `StudyAuditLogServlet`: usual adaptations in servlet (analogous to PR #471, for example)
- `studyAuditLog.jsp`: usual adaptations in JSP template (analogous to PR #471, for example)
- `StudyAuditLogTableTest`: new unit test for basic validation
