### PR TITLE
LCTable localisation and changes concerning `data-test-column` attribute

### DIFF
--- a/core/src/main/resources/org/akaza/openclinica/i18n/words.properties
+++ b/core/src/main/resources/org/akaza/openclinica/i18n/words.properties
@@ -3120,6 +3120,16 @@ mailNotification_Type.ENABLED=Enabled
 
 contactEmail=Project Manager Contact E-mail
 
+# Additional keys for LCTable library (prefix `lctable_`)
+lctable_no_results = No results.
+lctable_results = Results {0}-{1} of {2}.
+lctable_numeric_filter_message = Please enter digits only
+lctable_timestamp_filter_message = Please enter a valid format: yyyy, yyyy-MM, yyyy-MM-dd, yyyy-MM-dd hh, or yyyy-MM-dd hh:mm
+lctable_year_or_date_filter_message = Please enter a year (yyyy) or date in {0} format
+# Additional keys for AuditUserActivity table
+attempt_date = Attempt Date
+
+
 # Keys below this line existed only in the core copy of this bundle before
 # the i18n consolidation and are preserved unchanged (see README.md).
 footer.edition.1=Unsupported

--- a/web/src/main/java/org/akaza/openclinica/control/admin/AuditUserLoginTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/admin/AuditUserLoginTable.java
@@ -15,6 +15,7 @@ import org.akaza.openclinica.dao.hibernate.AuditUserLoginFilter;
 import org.akaza.openclinica.dao.hibernate.AuditUserLoginSort;
 import org.akaza.openclinica.domain.technicaladmin.AuditUserLoginBean;
 import org.akaza.openclinica.domain.technicaladmin.LoginStatus;
+import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.lctable.*;
 
 import static org.akaza.openclinica.lctable.LCTableColumnDef.*;
@@ -26,6 +27,8 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+
+import static org.akaza.openclinica.lctable.LCTableText.key;
 
 
 public class AuditUserLoginTable {
@@ -57,20 +60,20 @@ public class AuditUserLoginTable {
 
     // defines the configuration of columns for the AuditUserLogin table
     private static final List<LCTableColumnDef<AuditUserLoginBean>> COLUMNS = Arrays.asList(
-        textCol("userName", "User Name", 5, AuditUserLoginBean::getUserName),
-        textCol("loginAttemptDate", "Attempt Date", 7,
+        textCol("userName",         key("username2"),    "user-name", 5, AuditUserLoginBean::getUserName),
+        textCol("loginAttemptDate", key("attempt_date"), "login-attempt-date", 7,
             textFilter(TIMESTAMP_FILTER_FOR_HTML_VALIDATION, TIMESTAMP_FILTER_MESSAGE),
             AuditUserLoginBean::getLoginAttemptDate, LCTableUtil::timestampToString
         ),
-        enumCol("loginStatus", "Status", 7,
+        enumCol("loginStatus",      key("status"),       "login-status", 7,
             AuditUserLoginBean::getLoginStatus, Arrays.asList(LoginStatus.values()), LoginStatus::toString, LoginStatus::name
         ),
-        textCol("details", "Details", 3, AuditUserLoginBean::getDetails),
+        textCol("details",          key("details"),      "details", 3, AuditUserLoginBean::getDetails),
 
-        customTdCol("actions", "Actions", 4, NOT_SORTABLE, clearFilter(),
+        customTdColWithContext("actions", key("actions"), "actions", 4, NOT_SORTABLE, clearFilter(),
             AuditUserLoginBean::getUserAccountId,
-            (td, row) ->
-                td.of(actionLink(actionId("view", row), "View",
+            (td, row, context) ->
+                td.of(actionLink(actionId("view", row), context.words.getString("view"),
                     url("ViewUserAccount").param("userId", row.getUserAccountId()).param("viewFull", "yes"), "bt_View.gif", "view"))
         )
     );
@@ -104,7 +107,7 @@ public class AuditUserLoginTable {
     // rendering method putting all pieces together
     public String render(HttpServletRequest request) {
         final LCTableParams params = new LCTableParams(request.getQueryString(), this.table);
-        return this.table.render(request.getRequestURI(), params, request.getContextPath());
+        return this.table.render(request.getRequestURI(), params, request.getContextPath(), LocaleResolver.getLocale(request));
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/ListEventsForSubjectTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/ListEventsForSubjectTable.java
@@ -45,6 +45,7 @@ import org.akaza.openclinica.dao.submit.EventCRFDAO;
 import org.akaza.openclinica.dao.submit.SubjectDAO;
 import org.akaza.openclinica.dao.submit.SubjectGroupMapDAO;
 import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.lctable.*;
 import org.xmlet.htmlapifaster.Div;
 import org.xmlet.htmlapifaster.Td;
@@ -52,6 +53,8 @@ import org.xmlet.htmlapifaster.Td;
 import static org.akaza.openclinica.lctable.LCTableColumnDef.*;
 import static org.akaza.openclinica.lctable.LCTableUtil.*;
 import static org.akaza.openclinica.lctable.SafeUrl.url;
+import static org.akaza.openclinica.lctable.LCTableText.key;
+import static org.akaza.openclinica.lctable.LCTableText.literal;
 
 import javax.servlet.http.HttpServletRequest;
 import java.text.SimpleDateFormat;
@@ -224,17 +227,17 @@ public class ListEventsForSubjectTable {
     private List<LCTableColumnDef<ListEventsForSubjectRow>> buildColumns() {
         List<LCTableColumnDef<ListEventsForSubjectRow>> columns = new ArrayList<>();
 
-        columns.add(textCol("studySubject.label", resword.getString("study_subject_ID"), 0, row -> row.studySubject.getLabel()));
-        columns.add(enumColHidden("studySubject.status", resword.getString("subject_status"), 0,
+        columns.add(textCol      ("studySubject.label",  key("study_subject_ID"), "study-subject-id", 0, row -> row.studySubject.getLabel()));
+        columns.add(enumColHidden("studySubject.status", key("subject_status"),   "subject-status"  , 0,
             row -> row.studySubject.getStatus(), Status.toDropDownArrayList(), Status::getName, Status::getName
         ));
-        columns.add(textColHidden("enrolledAt", resword.getString("site_id"), 0, row -> row.enrolledAt));
-        columns.add(textColHidden("subject.charGender", resword.getString("gender"), 0,row -> String.valueOf(row.subject.getGender())));
+        columns.add(textColHidden("enrolledAt",          key("site_id"),          "site-id",          0, row -> row.enrolledAt));
+        columns.add(textColHidden("subject.charGender",  key("gender"),           "sex",              0,row -> String.valueOf(row.subject.getGender())));
 
         // one hidden column per active study-group-class (legacy default: hide Subject Status, Site, Gender and all group-class columns)
         for (StudyGroupClassBean sgc : studyGroupClasses) {
             List<StudyGroupBean> groupOptions = studyGroupDAO.findAllByGroupClass(sgc);
-            columns.add(enumColHiddenNotSortable("sgc_" + sgc.getId(), sgc.getName(), 0, groupOptions, StudyGroupBean::getName, StudyGroupBean::getName,
+            columns.add(enumColHiddenNotSortable("sgc_" + sgc.getId(), literal(sgc.getName()), null,0, groupOptions, StudyGroupBean::getName, StudyGroupBean::getName,
                 row -> {
                     GroupAssignment ga = row.groupAssignmentsByClassId.get(sgc.getId());
                     return ga == null ? "" : ga.groupName;
@@ -242,21 +245,21 @@ public class ListEventsForSubjectTable {
             ));
         }
 
-        columns.add(customTdCol("event.status", resword.getString("event_status"), 0, NOT_SORTABLE,
+        columns.add(customTdCol  ("event.status",        key("event_status"),     "event-status", 0, NOT_SORTABLE,
             new LCTableFilterDef.Select<>(SubjectEventStatus.toArrayList(), SubjectEventStatus::getName, SubjectEventStatus::getName),
             LCTablePopupColumn.perOccurrence(eventPopup, this::toEventStatusPopupContexts)
         ));
 
         // "Event Date": NOT_SORTABLE / NO_FILTER on purpose -- the legacy sort/filter for this column were already
         // broken (they act on the subject's creation date, not the displayed event date); see class javadoc.
-        columns.add(customTdCol("studySubject.createdDate", resword.getString("event_date"), 0, NOT_SORTABLE, NO_FILTER,
+        columns.add(customTdCol  ("studySubject.createdDate", key("event_date"),  "event-date", 0, NOT_SORTABLE, NO_FILTER,
             this::renderEventDateCell
         ));
 
         // one column per active top-level CRF of the selected event definition
         for (CRFBean crf : crfs) {
             LCTableColumnDef<ListEventsForSubjectRow> crfColumn = LCTableColumnDef.<ListEventsForSubjectRow>customTdCol(
-                "crf_" + crf.getId(), crf.getName(), 0, NOT_SORTABLE,
+                "crf_" + crf.getId(), literal(crf.getName()), null, 0, NOT_SORTABLE,
                 new LCTableFilterDef.Select<>(DataEntryStage.toArrayList(), DataEntryStage::getName, DataEntryStage::getName),
                 (td, row) -> renderCrfCell(td, row, crf)
             );
@@ -264,7 +267,7 @@ public class ListEventsForSubjectTable {
             columns.add(crfColumn);
         }
 
-        columns.add(customTdCol("actions", resword.getString("rule_actions"), 0, NOT_SORTABLE, LCTableFilterDef.clearFilter(), this::renderActionsCell));
+        columns.add(customTdCol("actions", key("rule_actions"), "actions", 0, NOT_SORTABLE, LCTableFilterDef.clearFilter(), this::renderActionsCell));
 
         return columns;
     }
@@ -463,7 +466,7 @@ public class ListEventsForSubjectTable {
 
     public String render(HttpServletRequest request) {
         final LCTableParams params = new LCTableParams(request.getQueryString(), this.table);
-        return this.table.render(request.getRequestURI(), params, request.getContextPath());
+        return this.table.render(request.getRequestURI(), params, request.getContextPath(), LocaleResolver.getLocale(request));
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTable.java
@@ -19,26 +19,12 @@ import org.akaza.openclinica.dao.managestudy.StudySubjectDAO;
 import org.akaza.openclinica.dao.submit.SubjectDAO;
 import org.akaza.openclinica.i18n.util.I18nFormatUtil;
 import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
-import org.akaza.openclinica.lctable.LCTable;
-import org.akaza.openclinica.lctable.LCTableColumnDef;
-import org.akaza.openclinica.lctable.LCTableData;
-import org.akaza.openclinica.lctable.LCTableFilterDef;
-import org.akaza.openclinica.lctable.LCTableParams;
-import org.akaza.openclinica.lctable.LCTableUtil;
-import org.akaza.openclinica.lctable.SafeUrl;
+import org.akaza.openclinica.i18n.core.LocaleResolver;
+import org.akaza.openclinica.lctable.*;
 import org.xmlet.htmlapifaster.Td;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
+import java.util.*;
 
 import static org.akaza.openclinica.lctable.LCTableColumnDef.NOT_SORTABLE;
 import static org.akaza.openclinica.lctable.LCTableColumnDef.SORTABLE;
@@ -49,6 +35,7 @@ import static org.akaza.openclinica.lctable.LCTableColumnDef.textCol;
 import static org.akaza.openclinica.lctable.LCTableFilterDef.clearFilter;
 import static org.akaza.openclinica.lctable.LCTableFilterDef.textFilter;
 import static org.akaza.openclinica.lctable.SafeUrl.url;
+import static org.akaza.openclinica.lctable.LCTableText.key;
 
 /**
  * LCTable-based study-subject audit-log index served by {@link StudyAuditLogServlet}.
@@ -89,50 +76,22 @@ public class StudyAuditLogTable {
     }
 
     private List<LCTableColumnDef<StudyAuditLogRow>> buildColumns() {
-        List<LCTableColumnDef<StudyAuditLogRow>> columns = new ArrayList<>();
-
-        columns.add(textColWithKey("studySubject.label", "study_subject_ID", SORTABLE,
-            textFilter(), row -> row.studySubject.getLabel()));
-        columns.add(textColWithKey("studySubject.secondaryLabel", "secondary_subject_ID", SORTABLE,
-            textFilter(), row -> row.studySubject.getSecondaryLabel()));
-        columns.add(textColWithKey("studySubject.oid", "study_subject_oid", SORTABLE,
-            textFilter(), row -> row.studySubject.getOid()));
-        columns.add(textColWithKey("subject.dateOfBirth", "date_of_birth", SORTABLE,
-            textFilter(DOB_FILTER_PATTERN, "Please enter a year (yyyy) or date in " + getDateFormat() + " format"),
-            row -> resolveBirthDay(row.subject.getDateOfBirth(), row.subject.isDobCollected())));
-        columns.add(textColWithKey("subject.uniqueIdentifier", "person_ID", SORTABLE,
-            textFilter(), row -> row.subject.getUniqueIdentifier()));
-        LCTableColumnDef<StudyAuditLogRow> ownerColumn = textCol(
-            "studySubject.owner", resword.getString("created_by"), 0, VISIBLE, NOT_SORTABLE,
-            textFilter(), row -> row.owner, UserAccountBean::getName
+        return Arrays.asList(
+            textCol("studySubject.label",          key("study_subject_ID"),     "study-subject-id",     0, textFilter(), row -> row.studySubject.getLabel()),
+            textCol("studySubject.secondaryLabel", key("secondary_subject_ID"), "secondary-subject-id", 0, textFilter(), row -> row.studySubject.getSecondaryLabel()),
+            textCol("studySubject.oid",            key("study_subject_oid"),    "study-subject-oid",    0, textFilter(), row -> row.studySubject.getOid()),
+            textCol("subject.dateOfBirth",         key("date_of_birth"),        "date-of-birth",        0,
+                textFilter(DOB_FILTER_PATTERN, LCTableText.formattedKey("lctable_year_or_date_filter_message", getDateFormat())),
+                row -> resolveBirthDay(row.subject.getDateOfBirth(), row.subject.isDobCollected())
+            ),
+            textCol("subject.uniqueIdentifier",    key("person_ID"),            "person-id",            0, textFilter(), row -> row.subject.getUniqueIdentifier()),
+            textCol("studySubject.owner",          key("created_by"),           "created-by",           0, textFilter(), row -> row.owner, UserAccountBean::getName),
+            enumCol("studySubject.status",         key("status"),               "status",               0,
+                row -> row.studySubject.getStatus(), Status.toActiveArrayList(), Status::getName,
+                status -> Integer.toString(status.getId())
+            ),
+            customTdCol("actions",                 key("actions"),              "actions",              0, NOT_SORTABLE, clearFilter(), this::renderActionsCell)
         );
-        ownerColumn.setTestAttributes(row -> Map.of("column", "created_by"));
-        columns.add(ownerColumn);
-
-        LCTableColumnDef<StudyAuditLogRow> statusColumn = enumCol(
-            "studySubject.status", resword.getString("status"), 0,
-            row -> row.studySubject.getStatus(), Status.toActiveArrayList(), Status::getName,
-            status -> Integer.toString(status.getId())
-        );
-        statusColumn.setTestAttributes(row -> Map.of("column", "status"));
-        columns.add(statusColumn);
-
-        columns.add(customTdColWithKey("actions", "actions", NOT_SORTABLE, clearFilter(), this::renderActionsCell));
-        return columns;
-    }
-
-    private LCTableColumnDef<StudyAuditLogRow> textColWithKey(String columnName, String resourceKey,
-            LCTableColumnDef.Sortability sortability, LCTableFilterDef filter,
-            Function<StudyAuditLogRow, String> renderer) {
-        return textCol(columnName, resword.getString(resourceKey), 0, VISIBLE, sortability, filter, renderer)
-            .setTestAttributes(row -> Map.of("column", resourceKey));
-    }
-
-    private LCTableColumnDef<StudyAuditLogRow> customTdColWithKey(String columnName, String resourceKey,
-            LCTableColumnDef.Sortability sortability, LCTableFilterDef filter,
-            BiConsumer<Td<?>, StudyAuditLogRow> renderer) {
-        return customTdCol(columnName, resword.getString(resourceKey), 0, sortability, filter, renderer)
-            .setTestAttributes(row -> Map.of("column", resourceKey));
     }
 
     private void renderActionsCell(Td<?> td, StudyAuditLogRow row) {
@@ -183,7 +142,7 @@ public class StudyAuditLogTable {
 
     public String render(HttpServletRequest request) {
         LCTableParams params = new LCTableParams(request.getQueryString(), table);
-        return table.render(request.getRequestURI(), params, request.getContextPath());
+        return table.render(request.getRequestURI(), params, request.getContextPath(), LocaleResolver.getLocale(request));
     }
 
     private static final class StudyAuditLogRow {

--- a/web/src/main/java/org/akaza/openclinica/control/popup/CrfStatusPopup.java
+++ b/web/src/main/java/org/akaza/openclinica/control/popup/CrfStatusPopup.java
@@ -157,7 +157,7 @@ public final class CrfStatusPopup {
         };
 
         return new LCPopup<>(ctx -> List.of(ctx.data), CrfStatusPopup::renderTriggerIcon, headerRenderer, Optional.empty(),
-            itemRenderer, "crf-trigger", "ViewSubjectsPopup");
+            itemRenderer, "crf-trigger", "ViewSubjectsPopup", resword);
     }
 
     /**

--- a/web/src/main/java/org/akaza/openclinica/control/popup/EventStatusPopup.java
+++ b/web/src/main/java/org/akaza/openclinica/control/popup/EventStatusPopup.java
@@ -171,7 +171,7 @@ public final class EventStatusPopup {
         row.div().attrClass("lc-popup-summary-line")
             .of(line -> {
                 String date = formatDate(occ.eventDate, resformat);
-                line.text(resword.getString("ocurrence") + " #" + (index + 1) + " of " + total + " \u00B7 ");
+                line.text(resword.getString("ocurrence") + " #" + (index + 1) + " " + resword.getString("of") + " " + total + " \u00B7 ");
                 if (!date.isEmpty()) {
                     line.text(date + " \u00B7 ");
                 }
@@ -294,7 +294,7 @@ public final class EventStatusPopup {
         };
 
         return new LCPopup<>(ctx -> ctx.occurrences, EventStatusPopup::renderTriggerIcons, headerRenderer, extraHeaderControl,
-            itemRenderer, "event-trigger", "ViewSubjectsPopup");
+            itemRenderer, "event-trigger", "ViewSubjectsPopup", resword);
     }
 
     // -- per-occurrence (listEventsForSubjects) -------------------------------------------------------------
@@ -380,7 +380,7 @@ public final class EventStatusPopup {
         };
 
         return new LCPopup<>(ctx -> ctx.occurrences, EventStatusPopup::renderTriggerIcons, headerRenderer, Optional.empty(),
-            itemRenderer, "event-trigger", "ViewSubjectsPopup");
+            itemRenderer, "event-trigger", "ViewSubjectsPopup", resword);
     }
 }
 

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListNotesTable.java
@@ -13,6 +13,7 @@ import org.akaza.openclinica.bean.login.UserAccountBean;
 import org.akaza.openclinica.bean.managestudy.DiscrepancyNoteBean;
 import org.akaza.openclinica.bean.managestudy.StudyBean;
 import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.lctable.*;
 import org.akaza.openclinica.service.DiscrepancyNotesSummary;
 import org.akaza.openclinica.service.managestudy.ViewNotesFilterCriteria;
@@ -24,6 +25,7 @@ import org.xmlet.htmlapifaster.Td;
 import static org.akaza.openclinica.lctable.LCTableColumnDef.*;
 import static org.akaza.openclinica.lctable.LCTableFilterDef.*;
 import static org.akaza.openclinica.lctable.SafeUrl.url;
+import static org.akaza.openclinica.lctable.LCTableText.key;
 
 import javax.servlet.http.HttpServletRequest;
 import java.text.SimpleDateFormat;
@@ -33,10 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
 
 /**
  * LCTable-based "listNotes" table ("Notes and Discrepancies" page, reachable via {@code ViewNotes}).
@@ -217,48 +216,46 @@ public class ListNotesTable {
     private List<LCTableColumnDef<DiscrepancyNoteBean>> buildColumns() {
         List<LCTableColumnDef<DiscrepancyNoteBean>> columns = new ArrayList<>();
 
-        columns.add(textColWithKey("studySubject.label", "study_subject_ID", 0, VISIBLE, SORTABLE, textFilter(), row -> row.getStudySub().getLabel()));
-        columns.add(customTdColWithKey("discrepancyNoteBean.disType", "type", 0, NOT_SORTABLE,
-            new LCTableFilterDef.Select<>(discNoteTypeFilterOptions, NoteFilterOption::getLabel, NoteFilterOption::getUrlParam),
+        columns.add(textCol    ("studySubject.label",                   key("study_subject_ID"),  "study_subject_ID",
+            0, VISIBLE, SORTABLE, textFilter(), row -> row.getStudySub().getLabel())
+        );
+        columns.add(customTdCol("discrepancyNoteBean.disType",          key("type"),              "type",
+            0, NOT_SORTABLE, new LCTableFilterDef.Select<>(discNoteTypeFilterOptions, NoteFilterOption::getLabel, NoteFilterOption::getUrlParam),
             this::renderNoteTypeCell
         ));
-        columns.add(customTdColWithKey("discrepancyNoteBean.resolutionStatus", "resolution_status", 0, NOT_SORTABLE,
+        columns.add(customTdCol("discrepancyNoteBean.resolutionStatus", key("resolution_status"), "resolution_status", 0, NOT_SORTABLE,
             new LCTableFilterDef.Select<>(resolutionStatusFilterOptions, NoteFilterOption::getLabel, NoteFilterOption::getUrlParam),
             this::renderResolutionStatusCell
         ));
-        columns.add(textColWithKey("siteId",                           "site_id",            0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getSiteId));
-        columns.add(textColWithKey("discrepancyNoteBean.createdDate",  "date_created",       0, HIDDEN,  SORTABLE,     textFilter(), DiscrepancyNoteBean::getCreatedDate, this::formatDate));
-        columns.add(textColWithKey("discrepancyNoteBean.updatedDate",  "date_updated",       0, HIDDEN,  NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getUpdatedDate, this::formatDate));
-        columns.add(textColWithKey("age",                              "days_open",          0, VISIBLE, SORTABLE,     textFilter("\\d*", "Please enter digits only"), DiscrepancyNoteBean::getAge,  Object::toString));
-        columns.add(textColWithKey("days",                             "days_since_updated", 0, VISIBLE, SORTABLE,     textFilter("\\d*", "Please enter digits only"), DiscrepancyNoteBean::getDays, Object::toString));
-        columns.add(textColWithKey("eventName",                        "event_name",         0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getEventName));
-        columns.add(textColWithKey("eventStartDate",                   "event_date",         0, HIDDEN,  NOT_SORTABLE, NO_FILTER,    DiscrepancyNoteBean::getEventStart, this::formatDate));
-        columns.add(textColWithKey("crfName",                          "CRF",                0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getCrfName));
-        columns.add(textColWithKey("crfStatus",                        "CRF_status",         0, HIDDEN,  NOT_SORTABLE, NO_FILTER,    DiscrepancyNoteBean::getCrfStatus));
-        columns.add(textColWithKey("entityName",                       "entity_name",        0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getEntityName));
-        columns.add(textColWithKey("entityValue",                      "entity_value",       0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getEntityValue));
-        columns.add(textColWithKey("discrepancyNoteBean.entityType",   "entity_type",        0, HIDDEN,  NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getEntityType));
-        columns.add(textColWithKey("discrepancyNoteBean.description",  "description",        0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getDescription));
-        columns.add(textColWithKey("discrepancyNoteBean.detailedNotes","detailed_notes",     0, HIDDEN,  NOT_SORTABLE, NO_FILTER,    DiscrepancyNoteBean::getDetailedNotes));
-        columns.add(textColWithKey("numberOfNotes",                    "of_notes",           0, HIDDEN,  NOT_SORTABLE, NO_FILTER,    DiscrepancyNoteBean::getNumChildren, x -> Integer.toString(x)));
-        columns.add(customTdColWithKey("discrepancyNoteBean.user",     "assigned_user",      0,          NOT_SORTABLE, textFilter(), this::renderAssignedUserCell));
-        columns.add(textColWithKey("discrepancyNoteBean.owner",        "owner",              0, HIDDEN,  NOT_SORTABLE, NO_FILTER,
+        columns.add(textCol    ("siteId",                            key("site_id"),            "site_id",            0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getSiteId));
+        columns.add(textCol    ("discrepancyNoteBean.createdDate",   key("date_created"),       "date_created",       0, HIDDEN,  SORTABLE,     textFilter(), DiscrepancyNoteBean::getCreatedDate, this::formatDate));
+        columns.add(textCol    ("discrepancyNoteBean.updatedDate",   key("date_updated"),       "date_updated",       0, HIDDEN,  NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getUpdatedDate, this::formatDate));
+        columns.add(textCol    ("age",                               key("days_open"),          "days_open",          0, VISIBLE, SORTABLE,     textFilter("\\d*", key("lctable_numeric_filter_message")), DiscrepancyNoteBean::getAge,  Object::toString));
+        columns.add(textCol    ("days",                              key("days_since_updated"), "days_since_updated", 0, VISIBLE, SORTABLE,     textFilter("\\d*", key("lctable_numeric_filter_message")), DiscrepancyNoteBean::getDays, Object::toString));
+        columns.add(textCol    ("eventName",                         key("event_name"),         "event_name",         0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getEventName));
+        columns.add(textCol    ("eventStartDate",                    key("event_date"),         "event_date",         0, HIDDEN,  NOT_SORTABLE, NO_FILTER,    DiscrepancyNoteBean::getEventStart, this::formatDate));
+        columns.add(textCol    ("crfName",                           key("CRF"),                "CRF",                0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getCrfName));
+        columns.add(textCol    ("crfStatus",                         key("CRF_status"),         "CRF_status",         0, HIDDEN,  NOT_SORTABLE, NO_FILTER,    DiscrepancyNoteBean::getCrfStatus));
+        columns.add(textCol    ("entityName",                        key("entity_name"),        "entity_name",        0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getEntityName));
+        columns.add(textCol    ("entityValue",                       key("entity_value"),       "entity_value",       0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getEntityValue));
+        columns.add(textCol    ("discrepancyNoteBean.entityType",    key("entity_type"),        "entity_type",        0, HIDDEN,  NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getEntityType));
+        columns.add(textCol    ("discrepancyNoteBean.description",   key("description"),        "description",        0, VISIBLE, NOT_SORTABLE, textFilter(), DiscrepancyNoteBean::getDescription));
+        columns.add(textCol    ("discrepancyNoteBean.detailedNotes", key("detailed_notes"),     "detailed_notes",     0, HIDDEN,  NOT_SORTABLE, NO_FILTER,    DiscrepancyNoteBean::getDetailedNotes));
+        columns.add(textCol    ("numberOfNotes",                     key("of_notes"), "of_notes",           0, HIDDEN,  NOT_SORTABLE, NO_FILTER,    DiscrepancyNoteBean::getNumChildren, x -> Integer.toString(x)));
+        columns.add(customTdCol("discrepancyNoteBean.user",          key("assigned_user"), "assigned_user",      0,          NOT_SORTABLE, textFilter(), this::renderAssignedUserCell));
+        columns.add(textCol    ("discrepancyNoteBean.owner",         key("owner"), "owner",              0, HIDDEN,  NOT_SORTABLE, NO_FILTER,
             row -> {
                 UserAccountBean owner = row.getOwner();
                 String ownerName = owner == null ? null : owner.getName();
                 return ownerName == null || ownerName.isEmpty() ? null : ownerName;
             }
         ));
-        columns.add(customTdColWithKey("actions", "actions", 0, NOT_SORTABLE, clearFilter(), this::renderActionsCell));
+        columns.add(customTdCol("actions", key("actions"), "actions", 0, NOT_SORTABLE, clearFilter(), this::renderActionsCell));
 
         return columns;
     }
 
     // -- Cell renderers -------------------------------------------------------------------------------
-
-    private static String orPlaceholder(String s) {
-        return s == null ? NULL_PLACEHOLDER : s;
-    }
 
     private void renderNoteTypeCell(Td<?> td, DiscrepancyNoteBean row) {
         DiscrepancyNoteType type = row.getDisType();
@@ -273,19 +270,6 @@ public class ListNotesTable {
         }
         Td<?> afterIcon = td.img().attrSrc(status.getIconFilePath()).attrAlt(status.getName()).__();
         afterIcon.text(" " + status.getName());
-    }
-
-    /** Entity names for non-itemData rows are resource-bundle keys. */
-    private String entityNameLabel(DiscrepancyNoteBean row) {
-        String entityName = row.getEntityName();
-        if (DiscrepancyNoteBean.ITEM_DATA.equals(row.getEntityType())) {
-            return orPlaceholder(entityName);
-        }
-        try {
-            return resword.getString(entityName);
-        } catch (MissingResourceException e) {
-            return "###" + entityName + "###";
-        }
     }
 
     private void renderAssignedUserCell(Td<?> td, DiscrepancyNoteBean row) {
@@ -329,23 +313,6 @@ public class ListNotesTable {
         return new SimpleDateFormat(getDateFormat()).format(date);
     }
 
-    // -- Column helpers: single method combining display name lookup + test attribute application ---
-
-    private <T> LCTableColumnDef<DiscrepancyNoteBean> textColWithKey(String columnName, String columnKey, double width, Visibility visibility, LCTableColumnDef.Sortability sortability, LCTableFilterDef filterDef, Function<DiscrepancyNoteBean, T> extractor, Function<T, String> renderer) {
-        return textCol(columnName, resword.getString(columnKey), width, visibility, sortability, filterDef, extractor, renderer)
-            .setTestAttributes(row -> Map.of("column", columnKey));
-    }
-
-    private <T> LCTableColumnDef<DiscrepancyNoteBean> textColWithKey(String columnName, String columnKey, double width, Visibility visibility, LCTableColumnDef.Sortability sortability, LCTableFilterDef filterDef, Function<DiscrepancyNoteBean, String> renderer) {
-        return textCol(columnName, resword.getString(columnKey), width, visibility, sortability, filterDef, renderer)
-            .setTestAttributes(row -> Map.of("column", columnKey));
-    }
-
-    private LCTableColumnDef<DiscrepancyNoteBean> customTdColWithKey(String columnName, String columnKey, double width, LCTableColumnDef.Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Td<?>, DiscrepancyNoteBean> renderer) {
-        return customTdCol(columnName, resword.getString(columnKey), width, sortability, filterDef, renderer)
-            .setTestAttributes(row -> Map.of("column", columnKey));
-    }
-
     // -- Data fetching -----------------------------------------------------------------------------
 
     private LCTableData<DiscrepancyNoteBean> fetchData(LCTableParams p) {
@@ -386,7 +353,7 @@ public class ListNotesTable {
 
     public String render(HttpServletRequest request) {
         LCTableParams params = new LCTableParams(request.getQueryString(), this.table);
-        return this.table.render(request.getRequestURI(), params, request.getContextPath());
+        return this.table.render(request.getRequestURI(), params, request.getContextPath(), LocaleResolver.getLocale(request));
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTable.java
+++ b/web/src/main/java/org/akaza/openclinica/control/submit/ListStudySubjectTable.java
@@ -38,15 +38,17 @@ import org.akaza.openclinica.dao.submit.EventCRFDAO;
 import org.akaza.openclinica.dao.submit.SubjectDAO;
 import org.akaza.openclinica.dao.submit.SubjectGroupMapDAO;
 import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+import org.akaza.openclinica.i18n.core.LocaleResolver;
 import org.akaza.openclinica.lctable.*;
 import org.akaza.openclinica.service.pmanage.ParticipantPortalRegistrar;
 import org.xmlet.htmlapifaster.Div;
 import org.xmlet.htmlapifaster.Td;
 
 import static org.akaza.openclinica.lctable.LCTableColumnDef.*;
-import static org.akaza.openclinica.lctable.LCTableFilterDef.*;
 import static org.akaza.openclinica.lctable.LCTableUtil.*;
 import static org.akaza.openclinica.lctable.SafeUrl.url;
+import static org.akaza.openclinica.lctable.LCTableText.key;
+import static org.akaza.openclinica.lctable.LCTableText.literal;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -175,20 +177,21 @@ public class ListStudySubjectTable {
     private List<LCTableColumnDef<FindSubjectsRow>> buildColumns() {
         List<LCTableColumnDef<FindSubjectsRow>> columns = new ArrayList<>();
 
-        columns.add(textCol("studySubject.label", resword.getString("study_subject_ID"), 0, row -> row.studySubject.getLabel()));
-        columns.add(enumColHidden("studySubject.status", resword.getString("subject_status"), 0,
+        columns.add(textCol      ("studySubject.label",          key("study_subject_ID"),  "study-subject-id", 0, row -> row.studySubject.getLabel()));
+        columns.add(enumColHidden("studySubject.status",         key("subject_status"),    "subject-status", 0,
             row -> row.studySubject.getStatus(), Status.toDropDownArrayList(), Status::getName, Status::getName
         ));
-        columns.add(textColHidden("enrolledAt", resword.getString("site_id"), 0, row -> row.enrolledAt));
-        columns.add(textColHidden("studySubject.oid", resword.getString("rule_oid"), 0, row -> row.studySubject.getOid()));
-        columns.add(textColHidden("subject.charGender", resword.getString("gender"), 0, row -> String.valueOf(row.subject.getGender())));
-        columns.add(textColHidden("studySubject.secondaryLabel", resword.getString("secondary_ID"), 0, row -> row.studySubject.getSecondaryLabel()));
-        columns.add(textColHidden("subject.uniqueIdentifier", resword.getString("subject_unique_ID"), 0, row -> row.subject.getUniqueIdentifier()));
+        columns.add(textColHidden("enrolledAt",                  key("site_id"),           "site-id", 0, row -> row.enrolledAt));
+        columns.add(textColHidden("studySubject.oid",            key("rule_oid"),          "oid", 0, row -> row.studySubject.getOid()));
+        columns.add(textColHidden("subject.charGender",          key("gender"),            "sex",0, row -> String.valueOf(row.subject.getGender())));
+        columns.add(textColHidden("studySubject.secondaryLabel", key("secondary_ID"),      "secondary-id", 0, row -> row.studySubject.getSecondaryLabel()));
+        columns.add(textColHidden("subject.uniqueIdentifier",    key("subject_unique_ID"), "person-id", 0, row -> row.subject.getUniqueIdentifier()));
 
         // one column per active study-group-class
         for (StudyGroupClassBean sgc : studyGroupClasses) {
             List<StudyGroupBean> groupOptions = studyGroupDAO.findAllByGroupClass(sgc);
-            columns.add(enumColNotSortable("sgc_" + sgc.getId(), sgc.getName(), 0, groupOptions, StudyGroupBean::getName, StudyGroupBean::getName,
+            columns.add(enumColNotSortable("sgc_" + sgc.getId(), literal(sgc.getName()), null, 0,
+                groupOptions, StudyGroupBean::getName, StudyGroupBean::getName,
                 row -> {
                     GroupAssignment ga = row.groupAssignmentsByClassId.get(sgc.getId());
                     return ga == null ? "" : ga.groupName;
@@ -202,7 +205,7 @@ public class ListStudySubjectTable {
             LCPopup<EventStatusPopup.Context, EventStatusPopup.EventOccurrence> eventPopup =
                 EventStatusPopup.aggregate(sed, studyBean, currentRole, currentUser, resword, resformat);
             LCTableColumnDef<FindSubjectsRow> eventColumn = LCTableColumnDef.<FindSubjectsRow>customTdCol(
-                "sed_" + sed.getId(), sed.getName(), 5, NOT_SORTABLE,
+                "sed_" + sed.getId(), literal(sed.getName()), null, 5, NOT_SORTABLE,
                 // SubjectEventStatus.getName() (Term.getName()) already resolves the translated display name via
                 // the terms resource bundle -- do NOT re-translate it here (that would look up the translated text
                 // itself as if it were a resource key, throwing MissingResourceException).
@@ -213,7 +216,7 @@ public class ListStudySubjectTable {
             columns.add(eventColumn);
         }
 
-        columns.add(customTdCol("actions", resword.getString("rule_actions"), 0, NOT_SORTABLE, LCTableFilterDef.clearFilter(), this::renderActionsCell));
+        columns.add(customTdCol("actions", key("rule_actions"), "actions", 0, NOT_SORTABLE, LCTableFilterDef.clearFilter(), this::renderActionsCell));
 
         return columns;
     }
@@ -407,7 +410,7 @@ public class ListStudySubjectTable {
 
     public String render(HttpServletRequest request) {
         final LCTableParams params = new LCTableParams(request.getQueryString(), this.table);
-        return this.table.render(request.getRequestURI(), params, request.getContextPath());
+        return this.table.render(request.getRequestURI(), params, request.getContextPath(), LocaleResolver.getLocale(request));
     }
 
 }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCPopup.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCPopup.java
@@ -17,6 +17,7 @@ import org.xmlet.htmlapifaster.FlowContent;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.ResourceBundle;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -48,6 +49,7 @@ public class LCPopup<T, I> {
     private final PopupItemRenderer<T, I> itemRenderer;
     private final String triggerClass;
     private final String popupModifierClass;
+    private final ResourceBundle resword;
 
     /**
      * @param itemsExtractor      {@code T -> } the (already-fetched/sorted, never empty) items to list in the popup
@@ -64,10 +66,11 @@ public class LCPopup<T, I> {
      *                            these stay table/kind-specific on purpose, since trigger *layout* -- one aggregate
      *                            trigger per cell vs. one per occurrence stacked vertically -- is not unified here)
      * @param popupModifierClass  extra CSS class applied to the popup box itself (e.g. {@code "ViewSubjectsPopup"})
+     * @param resword             the {@code resword} bundle for i18n of generic labels (e.g. "actions" in a {@link PopupItemLayout#COMPACT} row)
      */
     public LCPopup(Function<T, List<I>> itemsExtractor, BiConsumer<Div<?>, List<I>> triggerRenderer,
             BiConsumer<Div<?>, T> headerRenderer, Optional<BiConsumer<Div<?>, T>> extraHeaderControl,
-            PopupItemRenderer<T, I> itemRenderer, String triggerClass, String popupModifierClass) {
+                PopupItemRenderer<T, I> itemRenderer, String triggerClass, String popupModifierClass, ResourceBundle resword) {
         this.itemsExtractor = Objects.requireNonNull(itemsExtractor, "itemsExtractor");
         this.triggerRenderer = Objects.requireNonNull(triggerRenderer, "triggerRenderer");
         this.headerRenderer = Objects.requireNonNull(headerRenderer, "headerRenderer");
@@ -75,6 +78,7 @@ public class LCPopup<T, I> {
         this.itemRenderer = Objects.requireNonNull(itemRenderer, "itemRenderer");
         this.triggerClass = Objects.requireNonNull(triggerClass, "triggerClass");
         this.popupModifierClass = Objects.requireNonNull(popupModifierClass, "popupModifierClass");
+        this.resword = Objects.requireNonNull(resword, "resword");
     }
 
     /**
@@ -126,7 +130,7 @@ public class LCPopup<T, I> {
                 row.div().attrClass(compact ? "lc-popup-actions lc-popup-actions-compact" : "lc-popup-actions lc-popup-actions-vertical")
                     .of(actions -> {
                         if (compact) {
-                            actions.text("Actions: ");   // generic layout chrome owned by LCPopup itself; i18n deferred (see LCTable)
+                            actions.text(resword.getString("actions") + ": ");
                         }
                         for (PopupAction action : itemRenderer.actionsFor(context, item)) {
                             actions.of(actionLink(action.elementId, action.label, action.href, action.iconImage, action.showLabel, action.actionName));

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTable.java
@@ -18,9 +18,11 @@ import org.xmlet.htmlapifaster.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.StringWriter;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -30,7 +32,6 @@ import java.util.stream.IntStream;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.lang.String.format;
 
 /**
  * Renders a paginated/sortable/filterable HTML table using HTMX.
@@ -93,6 +94,19 @@ public class LCTable<T>  {
         this.columns      = columns;
         this.fetchData    = fetchData;
         this.stickyParamNames = stickyParamNames == null ? Collections.emptyList() : List.copyOf(stickyParamNames);
+        validateUniqueResourceKeys(columns);
+    }
+
+    private static <T> void validateUniqueResourceKeys(List<LCTableColumnDef<T>> columns) {
+        Map<String, Long> counts = columns.stream()
+            .map(column -> column.columnDisplayName.resourceKey())
+            .flatMap(java.util.Optional::stream)
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        counts.forEach((key, count) -> {
+            if (count > 1) {
+                throw new IllegalArgumentException("Duplicate key-backed column resource key: " + key);
+            }
+        });
     }
 
     public String getTableName() {
@@ -173,6 +187,7 @@ public class LCTable<T>  {
      * Clicking cycles through: no sort → ascending → descending → no sort.
      */
     private void renderColumnName(Tr<?> tr, LCTableColumnDef<T> col, LCTableContext<T> ctx) {
+        final String displayName = col.columnDisplayName.resolve(ctx.words, ctx.locale);
         // A columnWidth of 0 means "no explicit width": let the browser's auto table layout size the
         // column dynamically to fit the widest of its header/data content, rather than forcing it to 0.
         final String widthStyle = col.columnWidth > 0 ? ("width: " + col.columnWidth + "rem") : null;
@@ -180,7 +195,7 @@ public class LCTable<T>  {
             // Non-sortable column: just render the header text without a link
             Th<?> th = tr.th();
             if (widthStyle != null) th.attrStyle(widthStyle);
-            th.text(col.columnDisplayName).__();
+            th.text(displayName).__();
         } else {
             boolean isSorted = col.columnName.equals(ctx.sortProp);
             final String currentSortDir = isSorted ? ctx.sortDir : null;
@@ -195,7 +210,7 @@ public class LCTable<T>  {
                 .addAttr("data-test-sort", currentSortDir == null ? "none" : currentSortDir)    // <-- exposes current state for testing
                 .attrHref(href).of(hxGetAttrs(href, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
                 .of(a -> {
-                    a.span().attrClass("sort-header-text").text(col.columnDisplayName).__();
+                    a.span().attrClass("sort-header-text").text(displayName).__();
                     // Always render the sort indicator's <img>, so that the header's width already
                     // accounts for it whether or not the column is currently sorted (avoids the header --
                     // and hence the whole column -- growing/shrinking when sorting is toggled on/off).
@@ -230,7 +245,7 @@ public class LCTable<T>  {
                         .addAttr("data-testid", "toggle-hidden-columns-button")
                         .addAttr("data-test-action", ctx.showHiddenCols ? "hide" : "show-more")
                         .of(hxGetAttrs(toggleHref, NO_HX_INCLUDE, "#" + panelId, NO_HX_TRIGGER))
-                        .text(ctx.showHiddenCols ? "Hide" : "Show More")
+                        .text(ctx.words.getString(ctx.showHiddenCols ? "hide" : "show_more"))
                         .__();
                 }
                 // Custom, non-tabular controls (see addCustomToolbarControl), in the order they were added --
@@ -271,7 +286,7 @@ public class LCTable<T>  {
             String rowClass = ((i+1) % 2 == 0) ? "even" : "odd";    // use (i+1) to start from 1 for class assignment
             Tr<?> tr = tbody.tr().attrClass(rowClass).of(testAttrs(rowTestAttributes.apply(item)));
             columns.forEach(col -> {
-                if (shouldRenderColumn(col, ctx)) col.cellRenderer.accept(tr, item);
+                if (shouldRenderColumn(col, ctx)) col.cellRenderer.render(tr, item, ctx);
             });
             tr.__();
         });
@@ -330,10 +345,11 @@ public class LCTable<T>  {
      * @param entityPath the path to the entity for which the table is being rendered
      * @param params the parameters for fetching data (page number, page size, sorting, filters, etc.)
      * @param resourcePath the path to the resources needed for rendering the table
+     * @param locale request locale used to resolve all table-owned text
      * @return the rendered HTML string for the table
      */
-    public String render(String entityPath, LCTableParams params, String resourcePath) {
-        final LCTableContext<T> ctx = new LCTableContext<>(entityPath, params, fetchData, resourcePath);
+    public String render(String entityPath, LCTableParams params, String resourcePath, Locale locale) {
+        final LCTableContext<T> ctx = new LCTableContext<>(entityPath, params, fetchData, resourcePath, locale);
         return renderTableHtml(ctx);
     }
 
@@ -346,7 +362,10 @@ public class LCTable<T>  {
         Tfoot<?> footer = tfoot.attrClass("statusBar").addAttr("data-testid", "lctable-status-bar");
         Td<?> td = footer.tr().td().attrColspan((int) renderedColumnCount(ctx));
         final int count = ctx.data.totalCountWithFilter;
-        td.text(count == 0 ? "No results." : format("Results %d-%d of %d.", from, to, count)).__();
+        String status = count == 0
+            ? ctx.words.getString("lctable_no_results")
+            : new MessageFormat(ctx.words.getString("lctable_results"), ctx.locale).format(new java.lang.Object[] {from, to, count});
+        td.text(status).__();
         footer.__(); // div.table-footer
     }
 
@@ -402,7 +421,8 @@ public class LCTable<T>  {
     /** Builds the {@code select} element for 'maxRows' and appends it into the provided div. */
     private void buildSelectMaxRowsSelect(Div<?> div, LCTableContext<T> ctx) {
         if (HIDE_PAGINATION_TOOLS_FOR_SINGLE_PAGE_TABLE && ctx.totalPages <= 1) return;
-        div.label().text("").__();    // replace "" by "Rows: " if you want to make explicit what the select element is for
+        // Deliberately blank. Any future visible label must be a resource key resolved from ctx.words.
+        div.label().text("").__();
         div.select()
             .attrId(tableName + "-select-max-rows")
             .attrName(PARAM_MAX_ROWS)

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableColumnDef.java
@@ -56,8 +56,11 @@ public class LCTableColumnDef<T> {
     /** Internal column name used by controllers / query params. */
     public final String columnName;
 
-    /** Human-facing header text shown in the table. */
-    public final String columnDisplayName;
+    /** Human-facing column name shown in the table header, retained as a key or literal until rendering. */
+    public final LCTableText columnDisplayName;
+
+    /** Optional test name for the column, used for testing purposes as value of the @code data-test-column attributes */
+    public final String columnTestName;
 
     /** Width of the column (in rem) */
     public final double columnWidth;
@@ -72,14 +75,25 @@ public class LCTableColumnDef<T> {
     public final LCTableFilterDef filterDef;                // null if no filter is foreseen for this column
 
     /** Closure that writes the cell content for a given row bean into the HtmlFlow row element. */
-    public BiConsumer<Tr<?>, T> cellRenderer;
+    public CellRenderer<T> cellRenderer;
+
+    @FunctionalInterface
+    public interface CellRenderer<T> {
+        void render(Tr<?> rowElement, T row, LCTableContext<T> context);
+    }
+
+    @FunctionalInterface
+    public interface ContextCellRenderer<T> {
+        void render(Td<?> cell, T row, LCTableContext<T> context);
+    }
 
     private Function<T, Map<String, String>> testAttributes = row -> Collections.emptyMap();
 
     // General constructor
-    public LCTableColumnDef(String columnName, String columnDisplayName, double columnWidth, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
-        this.columnName = columnName;
-        this.columnDisplayName = columnDisplayName;
+    public LCTableColumnDef(String columnName, LCTableText columnDisplayName, String columnTestName, double columnWidth, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, CellRenderer<T> cellRenderer) {
+        this.columnName = Objects.requireNonNull(columnName, "columnName");
+        this.columnDisplayName = Objects.requireNonNull(columnDisplayName, "columnDisplayName");
+        this.columnTestName = columnTestName;
         this.columnWidth = columnWidth;
         this.visibility = visibility;
         this.sortability = sortability;
@@ -99,9 +113,19 @@ public class LCTableColumnDef<T> {
         return this;
     }
 
+    private void applyBodyCellAttributes(Td<?> td, T row) {
+        if (columnTestName != null) td.addAttr("data-test-column", columnTestName);
+        if (row == null) return;
+        Map<String, String> attributes = testAttributes.apply(row);
+        if (attributes.containsKey("column")) {
+            throw new IllegalArgumentException("Error in '" + columnName + "' column definition: 'testAttributes' must not contain 'column' attribute, specify the 'data-test-column' attribute via 'columnTestName' instead");
+        }
+        td.of(LCTableUtil.testAttrs(attributes));
+    }
+
     // Basic factory method
-    public static <T> LCTableColumnDef<T> columnDef(String columnName, String displayName, double columnWidth, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Tr<?>, T> cellRenderer) {
-        return new LCTableColumnDef<>(columnName, displayName, columnWidth, visibility, sortability, filterDef, cellRenderer);
+    public static <T> LCTableColumnDef<T> columnDef(String columnName, LCTableText displayName, String columnTestName, double columnWidth, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, CellRenderer<T> cellRenderer) {
+        return new LCTableColumnDef<>(columnName, displayName, columnTestName, columnWidth, visibility, sortability, filterDef, cellRenderer);
     }
 
     // --- 1. Null-safe cell generator ('Optional'-based) ---
@@ -109,16 +133,16 @@ public class LCTableColumnDef<T> {
     /**
      * Evaluates the Optional pipeline, safely rendering the value or a fallback '—'.
      */
-    private static <T, V> BiConsumer<Tr<?>, T> nullSafeCell(
+    private static <T, V> CellRenderer<T> nullSafeCell(
         LCTableColumnDef<T> col,
         Function<Optional<T>, Optional<V>> pipeline,
         BiConsumer<Td<?>, V> finish
     ) {
-        return (tr, row) -> {
+        return (tr, row, context) -> {
             Td<?> td = tr.td();
             if (col.columnName != null) td.attrClass("lc-col-" + col.columnName);
+            col.applyBodyCellAttributes(td, row);
             Optional<T> rowOpt = Optional.ofNullable(row);
-            rowOpt.ifPresent(value -> td.of(LCTableUtil.testAttrs(col.testAttributes.apply(value))));
             pipeline.apply(rowOpt).ifPresentOrElse(
                 val -> finish.accept(td, val),
                 () -> td.text(NULL_PLACEHOLDER)
@@ -129,125 +153,142 @@ public class LCTableColumnDef<T> {
 
     // --- 2. Null-safe text renderers ---
 
-    private static <T, V> LCTableColumnDef<T> nullSafeColumn(String columnName, String displayName, double width,
+    private static <T, V> LCTableColumnDef<T> nullSafeColumn(String columnName, LCTableText displayName, String columnTestName, double width,
             Visibility visibility, Sortability sortability, LCTableFilterDef filterDef,
             Function<Optional<T>, Optional<V>> pipeline, BiConsumer<Td<?>, V> finish) {
-        LCTableColumnDef<T> col = new LCTableColumnDef<>(columnName, displayName, width, visibility, sortability, filterDef, null);
+        LCTableColumnDef<T> col = new LCTableColumnDef<>(columnName, displayName, columnTestName, width, visibility, sortability, filterDef, null);
         col.cellRenderer = nullSafeCell(col, pipeline, finish);
         return col;
     }
 
-    private static <T> LCTableColumnDef<T> nullSafeTextColumn(String columnName, String displayName, double width,
+    private static <T> LCTableColumnDef<T> nullSafeTextColumn(String columnName, LCTableText displayName, String columnTestName, double width,
             Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return nullSafeColumn(columnName, displayName, width, visibility, sortability, filterDef,
+        return nullSafeColumn(columnName, displayName, columnTestName, width, visibility, sortability, filterDef,
             row -> row.map(renderer), TextGroup::text);
     }
 
-    private static <T, F> LCTableColumnDef<T> nullSafeTextColumn(String columnName, String displayName, double width,
+    private static <T, F> LCTableColumnDef<T> nullSafeTextColumn(String columnName, LCTableText displayName, String columnTestName, double width,
             Visibility visibility, Sortability sortability, LCTableFilterDef filterDef,
             Function<T, F> extractor, Function<F, String> renderer) {
-        return nullSafeColumn(columnName, displayName, width, visibility, sortability, filterDef,
+        return nullSafeColumn(columnName, displayName, columnTestName, width, visibility, sortability, filterDef,
             row -> row.map(extractor).map(renderer), TextGroup::text);
     }
 
     // --- 3. Column factory methods for text columns ---
 
-    public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, visibility, sortability, filterDef, renderer);
+    public static <T> LCTableColumnDef<T> textCol(String name, LCTableText displayName, String testName, double width, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, Function<T, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, visibility, sortability, filterDef, renderer);
     }
 
-    public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, visibility, sortability, filterDef, extractor, renderer);
+    public static <T, F> LCTableColumnDef<T> textCol(String name, LCTableText displayName, String testName, double width, Visibility visibility, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, visibility, sortability, filterDef, extractor, renderer);
     }
 
-    public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Visibility visibility, Sortability sortability, Function<T, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, visibility, sortability, new LCTableFilterDef.Text(), renderer);
+    public static <T> LCTableColumnDef<T> textCol(String name, LCTableText displayName, String testName, double width, Visibility visibility, Sortability sortability, Function<T, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, visibility, sortability, new LCTableFilterDef.Text(), renderer);
     }
 
-    public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Visibility visibility, Sortability sortability, Function<T, F> extractor, Function <F, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, visibility, sortability, new LCTableFilterDef.Text(), extractor, renderer);
+    public static <T, F> LCTableColumnDef<T> textCol(String name, LCTableText displayName, String testName, double width, Visibility visibility, Sortability sortability, Function<T, F> extractor, Function <F, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, visibility, sortability, new LCTableFilterDef.Text(), extractor, renderer);
     }
 
-    public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Function<T, String> renderer) {
-        return textCol(columnName, displayName, width, VISIBLE, SORTABLE, renderer);
+    public static <T> LCTableColumnDef<T> textCol(String name, LCTableText displayName, String testName, double width, Function<T, String> renderer) {
+        return textCol(name, displayName, testName, width, VISIBLE, SORTABLE, renderer);
     }
 
-    public static <T> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, Function<T, String> renderer) {
-        return textCol(columnName, displayName, width, HIDDEN, SORTABLE, renderer);
-
+    public static <T> LCTableColumnDef<T> textColHidden(String name, LCTableText displayName, String testName, double width, Function<T, String> renderer) {
+        return textCol(name, displayName, testName, width, HIDDEN, SORTABLE, renderer);
     }
 
-    public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, Function<T, F> extractor, Function<F, String> renderer) {
-        return textCol(columnName, displayName, width, VISIBLE, SORTABLE, extractor, renderer);
+    public static <T, F> LCTableColumnDef<T> textCol(String name, LCTableText displayName, String testName, double width, Function<T, F> extractor, Function<F, String> renderer) {
+        return textCol(name, displayName, testName, width, VISIBLE, SORTABLE, extractor, renderer);
     }
 
-    public static <T, F> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, Function<T, F> extractor, Function<F, String> renderer) {
-        return textCol(columnName, displayName, width, HIDDEN, SORTABLE, extractor, renderer);
+    public static <T, F> LCTableColumnDef<T> textColHidden(String name, LCTableText displayName, String testName, double width, Function<T, F> extractor, Function<F, String> renderer) {
+        return textCol(name, displayName, testName, width, HIDDEN, SORTABLE, extractor, renderer);
     }
 
-    public static <T> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, filterDef, renderer);
+    public static <T> LCTableColumnDef<T> textCol(String name, LCTableText displayName, String testName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, VISIBLE, SORTABLE, filterDef, renderer);
     }
 
-    public static <T> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, filterDef, renderer);
+    public static <T> LCTableColumnDef<T> textColHidden(String name, LCTableText displayName, String testName, double width, LCTableFilterDef filterDef, Function<T, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, HIDDEN, SORTABLE, filterDef, renderer);
     }
 
-    public static <T, F> LCTableColumnDef<T> textCol(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, filterDef, extractor, renderer);
+    public static <T, F> LCTableColumnDef<T> textCol(String name, LCTableText displayName, String testName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, VISIBLE, SORTABLE, filterDef, extractor, renderer);
     }
 
-    public static <T, F> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, filterDef, extractor, renderer);
+    public static <T, F> LCTableColumnDef<T> textColHidden(String name, LCTableText displayName, String testName, double width, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, HIDDEN, SORTABLE, filterDef, extractor, renderer);
     }
 
-    public static <T> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, sortability, filterDef, renderer);
+    public static <T> LCTableColumnDef<T> textColHidden(String name, LCTableText displayName, String testName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, HIDDEN, sortability, filterDef, renderer);
     }
 
-    public static <T, F> LCTableColumnDef<T> textColHidden(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
-        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, sortability, filterDef, extractor, renderer);
+    public static <T, F> LCTableColumnDef<T> textColHidden(String name, LCTableText displayName, String testName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> extractor, Function<F, String> renderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, HIDDEN, sortability, filterDef, extractor, renderer);
     }
 
 
     // --- 4. Column factory methods for enum-like types (similar to textCol, but with list of allowed value and 'select' filter ---
 
-    public static <T, V> LCTableColumnDef<T> enumCol(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
+    public static <T, V> LCTableColumnDef<T> enumCol(String name, LCTableText displayName, String testName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
     }
 
-    public static <T, V> LCTableColumnDef<T> enumColHidden(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
+    public static <T, V> LCTableColumnDef<T> enumColHidden(String name, LCTableText displayName, String testName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
     }
 
-    public static <T, V> LCTableColumnDef<T> enumColNotSortable(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
+    public static <T, V> LCTableColumnDef<T> enumColNotSortable(String name, LCTableText displayName, String testName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
     }
 
-    public static <T, V> LCTableColumnDef<T> enumColHiddenNotSortable(String columnName, String displayName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
-        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
+    public static <T, V> LCTableColumnDef<T> enumColHiddenNotSortable(String name, LCTableText displayName, String testName, double width, List<V> filterValues, Function<V, String> filterRenderer, Function<V, String> urlParamConverter, Function<T, String> colRenderer) {
+        return nullSafeTextColumn(name, displayName, testName, width, HIDDEN, NOT_SORTABLE, new LCTableFilterDef.Select<>(filterValues, filterRenderer, urlParamConverter), colRenderer);
     }
 
-    public static <T, V> LCTableColumnDef<T> enumCol(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
+    public static <T, V> LCTableColumnDef<T> enumCol(String name, LCTableText displayName, String testName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
+        return nullSafeTextColumn(name, displayName, testName, width, VISIBLE, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
     }
 
-    public static <T, V> LCTableColumnDef<T> enumColHidden(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return nullSafeTextColumn(columnName, displayName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
+    public static <T, V> LCTableColumnDef<T> enumColHidden(String name, LCTableText displayName, String testName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
+        return nullSafeTextColumn(name, displayName, testName, width, HIDDEN, SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
     }
 
-    public static <T, V> LCTableColumnDef<T> enumColNotSortable(String columnName, String displayName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
-        return nullSafeTextColumn(columnName, displayName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
+    public static <T, V> LCTableColumnDef<T> enumColNotSortable(String name, LCTableText displayName, String testName, double width, Function<T, V> extractor, List<V> enumValues, Function<V, String> renderer, Function<V, String> urlParamConverter) {
+        return nullSafeTextColumn(name, displayName, testName, width, VISIBLE, NOT_SORTABLE, new LCTableFilterDef.Select<>(enumValues, renderer, urlParamConverter), extractor, renderer);
     }
 
     // --- 5. Column factory methods for custom 'td' rendering ---
 
-    public static <T> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Td<?>, T> renderer) {
-        return nullSafeColumn(columnName, displayName, width, VISIBLE, sortability, filterDef, Function.identity(), renderer);
+    public static <T> LCTableColumnDef<T> customTdCol(String name, LCTableText displayName, String testName, double width, Sortability sortability, LCTableFilterDef filterDef, BiConsumer<Td<?>, T> renderer) {
+        return nullSafeColumn(name, displayName, testName, width, VISIBLE, sortability, filterDef, Function.identity(), renderer);
+    }
+
+    /** Custom cell renderer that can resolve request-scoped table text through its context. */
+    public static <T, F> LCTableColumnDef<T> customTdColWithContext(String name, LCTableText displayName, String testName, double width,
+            Sortability sortability, LCTableFilterDef filterDef, Function<T, F> presenceKey, ContextCellRenderer<T> renderer) {
+        LCTableColumnDef<T> col = new LCTableColumnDef<>(name, displayName, testName, width, VISIBLE, sortability, filterDef, null);
+        col.cellRenderer = (tr, row, context) -> {
+            Td<?> td = tr.td();
+            td.attrClass("lc-col-" + col.columnName);
+            col.applyBodyCellAttributes(td, row);
+            if (row != null && presenceKey.apply(row) != null) {
+                renderer.render(td, row, context);
+            } else {
+                td.text(NULL_PLACEHOLDER);
+            }
+            td.__();
+        };
+        return col;
     }
 
     /**
-     * Same as {@link #customTdCol(String, String, double, Sortability, LCTableFilterDef, BiConsumer)}, but skips
+    * Same as {@link #customTdCol(String, LCTableText, String, double, Sortability, LCTableFilterDef, BiConsumer)}, but skips
      * rendering (falling back to {@link #NULL_PLACEHOLDER}) when {@code presenceKey.apply(row)} is null -- for
      * columns whose content depends on a nullable, row-specific value (typically a foreign-key id) that may
      * legitimately be absent. {@code renderer} still receives the full row, so it can access whatever fields it needs.
@@ -255,8 +296,8 @@ public class LCTableColumnDef<T> {
      * @param presenceKey extracts the nullable value whose presence is required to render this cell's content
      * @param renderer    renders the cell's content for a given row (only called if {@code presenceKey.apply(row) != null})
      */
-    public static <T, F> LCTableColumnDef<T> customTdCol(String columnName, String displayName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> presenceKey, BiConsumer<Td<?>, T> renderer) {
-        return nullSafeColumn(columnName, displayName, width, VISIBLE, sortability, filterDef,
+    public static <T, F> LCTableColumnDef<T> customTdCol(String name, LCTableText displayName, String testName, double width, Sortability sortability, LCTableFilterDef filterDef, Function<T, F> presenceKey, BiConsumer<Td<?>, T> renderer) {
+        return nullSafeColumn(name, displayName, testName, width, VISIBLE, sortability, filterDef,
             row -> row.filter(r -> presenceKey.apply(r) != null), renderer);
     }
 

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableContext.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableContext.java
@@ -10,8 +10,13 @@
  */
 package org.akaza.openclinica.lctable;
 
+import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
+
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.ResourceBundle;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Collectors;
@@ -35,6 +40,8 @@ public final class LCTableContext<T> {
     // paths (derived from the request URL)
     public final String entityPath;
     public final String resourcePath;
+    public final Locale locale;
+    public final ResourceBundle words;
 
     // fetched data for the current page (page, sorting and filtering according to the parameters)
     public final LCTableData<T> data;       // data items (rows) in current page
@@ -46,7 +53,8 @@ public final class LCTableContext<T> {
 
     // -- Constructor -----------------------------------------------------------
 
-    public LCTableContext(String entityPath, LCTableParams params, Function<LCTableParams, LCTableData<T>> fetchData, String resourcePath) {
+        public LCTableContext(String entityPath, LCTableParams params, Function<LCTableParams, LCTableData<T>> fetchData,
+            String resourcePath, Locale locale) {
         this.page = params.page; // 0-based, converted from 1-based URL in LCTableParams
         this.maxRows = params.maxRows;
         this.sortProp = params.sortProp;
@@ -54,10 +62,12 @@ public final class LCTableContext<T> {
         this.filters = params.filters;
         this.showHiddenCols = params.showHiddenCols;
         this.stickyParams = params.stickyParams;
+        this.locale = Objects.requireNonNull(locale, "locale");
         this.data = fetchData.apply(params);
 
         this.entityPath = entityPath;
         this.resourcePath = resourcePath;
+        this.words = ResourceBundleProvider.getWordsBundle(locale);
 
         final int pageSize = this.maxRows;
         final int totalCountWithFilter = data.totalCountWithFilter;

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableFilterDef.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableFilterDef.java
@@ -27,7 +27,7 @@ public abstract class LCTableFilterDef {
     /*** Factory methods for creating a text filter definition. */
     public static Text textFilter() { return new Text(); }
     public static Text textFilter(String pattern) { return new Text(pattern, null); }
-    public static Text textFilter(String pattern, String message) { return new Text(pattern, message); }
+    public static Text textFilter(String pattern, LCTableText message) { return new Text(pattern, message); }
 
     /*** Factory methods for creating a select filter definition. */
     public static <T> Select<T> selectFilter(List<T> values, Function<T, String> valueToString) {
@@ -45,14 +45,14 @@ public abstract class LCTableFilterDef {
      */
     public static final class Text extends LCTableFilterDef {
         public final String pattern;   // Regex pattern for HTML5 validation
-        public final String message;   // Tooltip message displaying requested format
+        public final LCTableText message;   // Tooltip message displaying requested format
 
         public Text() {
             this.pattern = null;
             this.message = null;
         }
 
-        public Text(String pattern, String message) {
+        public Text(String pattern, LCTableText message) {
             this.pattern = pattern;
             this.message = message;
         }
@@ -81,7 +81,7 @@ public abstract class LCTableFilterDef {
                 if (this.pattern != null) {
                     input.attrPattern(this.pattern);
                     if (this.message != null) {
-                        input.attrTitle(this.message);
+                        input.attrTitle(this.message.resolve(ctx.words, ctx.locale));
                     }
                     // Cancel the debounced request if the value is no longer valid by the time it actually fires.
                     input.addAttr("hx-on:htmx:before-request", "if(!this.validity.valid){event.preventDefault();}");
@@ -139,7 +139,7 @@ public abstract class LCTableFilterDef {
                 return Optional.empty(); // No filtering requested
             } else {
                 // Find the domain object whose string representation matches the submitted text
-                return values.stream().filter(val -> label(val).equals(paramValue)).findFirst();       // empty if nothing found
+                return values.stream().filter(val -> urlParam(val).equals(paramValue)).findFirst();       // empty if nothing found
             }
         }
 
@@ -203,7 +203,7 @@ public abstract class LCTableFilterDef {
                 .addAttr("data-testid", "clear-filter-button")
                 .addAttr("data-test-column", col.columnName)     // this refers to the column where the button appears, but the button clears all filters, not just that column
                 .of(hxGetAttrs(ctx.entityPath, selector.toString(), "#" + table.panelId, "click"))
-                .text("Clear Filter")
+                .text(ctx.words.getString("table_clear_filter"))
                 .__().__();
         }
     }

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableText.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableText.java
@@ -1,0 +1,57 @@
+/*
+ * LibreClinica is distributed under the
+ * GNU Lesser General Public License (GNU LGPL).
+ *
+ * For details see: https://libreclinica.org/license
+ * copyright (C) 2026 LibreClinica
+ */
+package org.akaza.openclinica.lctable;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ResourceBundle;
+
+/** Immutable human-facing text that is either a resource key or a literal value. */
+public final class LCTableText {
+    private final String value;
+    private final boolean resourceKey;
+    private final List<String> arguments;
+
+    private LCTableText(String value, boolean resourceKey, List<String> arguments) {
+        this.value = Objects.requireNonNull(value, resourceKey ? "resourceKey" : "text");
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException(resourceKey ? "resourceKey must not be empty" : "text must not be empty");
+        }
+        this.resourceKey = resourceKey;
+        this.arguments = List.copyOf(arguments);
+    }
+
+    public static LCTableText key(String resourceKey) {
+        return new LCTableText(resourceKey, true, List.of());
+    }
+
+    public static LCTableText formattedKey(String resourceKey, String argument) {
+        return new LCTableText(resourceKey, true, List.of(Objects.requireNonNull(argument, "argument")));
+    }
+
+    public static LCTableText literal(String text) {
+        return new LCTableText(text, false, List.of());
+    }
+
+    public String resolve(ResourceBundle words, Locale locale) {
+        Objects.requireNonNull(words, "words");
+        Objects.requireNonNull(locale, "locale");
+        if (!resourceKey) {
+            return value;
+        }
+        String pattern = words.getString(value);
+        return arguments.isEmpty() ? pattern : new MessageFormat(pattern, locale).format(arguments.toArray(new String[0]));
+    }
+
+    public Optional<String> resourceKey() {
+        return resourceKey ? Optional.of(value) : Optional.empty();
+    }
+}

--- a/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
+++ b/web/src/main/java/org/akaza/openclinica/lctable/LCTableUtil.java
@@ -29,8 +29,7 @@ public class LCTableUtil {
     public static final String TIMESTAMP_FILTER_FOR_HTML_VALIDATION =
         "(?:(?:(?:00|20)(?:00|0[48]|[2468][048]|[13579][26])|(?:0[1-9]|1\\d)(?:0[48]|[2468][048]|[13579][26]))(?:-(?:(?:0[13578]|1[02])(?:-(?:0[1-9]|[12]\\d|3[01]))?|(?:0[469]|11)(?:-(?:0[1-9]|[12]\\d|30))?|02(?:-(?:0[1-9]|1\\d|2[0-9]))?))?|(?:(?:00|20)(?:0[1-35-79]|[13579][01345789]|[2468][1-35-79])|(?:0[1-9]|1\\d)(?:00|0[1-35-79]|[13579][01345789]|[2468][1-35-79]))(?:-(?:(?:0[13578]|1[02])(?:-(?:0[1-9]|[12]\\d|3[01]))?|(?:0[469]|11)(?:-(?:0[1-9]|[12]\\d|30))?|02(?:-(?:0[1-9]|1\\d|2[0-8]))?))?)(?: (?:[01]\\d|2[0-3])(?::[0-5]\\d)?)?";
 
-    public static final String TIMESTAMP_FILTER_MESSAGE =
-        "Please enter a valid format: yyyy, yyyy-MM, yyyy-MM-dd, yyyy-MM-dd hh, or yyyy-MM-dd hh:mm (years up to 2099)";
+    public static final LCTableText TIMESTAMP_FILTER_MESSAGE = LCTableText.key("lctable_timestamp_filter_message");
 
     public static String timestampToString(java.util.Date date) {
         return date.toInstant().atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));

--- a/web/src/test/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTableTest.java
+++ b/web/src/test/java/org/akaza/openclinica/control/managestudy/StudyAuditLogTableTest.java
@@ -22,6 +22,7 @@ import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Locale;
 
 import static org.mockito.Matchers.any;
@@ -71,6 +72,7 @@ public class StudyAuditLogTableTest extends TestCase {
         when(request.getQueryString()).thenReturn(null);
         when(request.getRequestURI()).thenReturn("/StudyAuditLog");
         when(request.getContextPath()).thenReturn("");
+        when(request.getLocales()).thenReturn(Collections.enumeration(Collections.singletonList(Locale.ENGLISH)));
 
         String html = new StudyAuditLogTable(
             studySubjectDao, subjectDao, userAccountDao, study, Locale.ENGLISH

--- a/web/src/test/java/org/akaza/openclinica/lctable/LCTableTest.java
+++ b/web/src/test/java/org/akaza/openclinica/lctable/LCTableTest.java
@@ -4,6 +4,7 @@
 package org.akaza.openclinica.lctable;
 
 import junit.framework.TestCase;
+import org.akaza.openclinica.i18n.util.ResourceBundleProvider;
 import org.akaza.openclinica.lctable.LCPopup.PopupAction;
 import org.akaza.openclinica.lctable.LCPopup.PopupItemLayout;
 import org.akaza.openclinica.lctable.LCPopup.PopupItemRenderer;
@@ -11,18 +12,37 @@ import org.xmlet.htmlapifaster.Div;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.ResourceBundle;
+
+import static org.mockito.Mockito.mock;
 
 import static org.akaza.openclinica.lctable.LCTableColumnDef.NOT_SORTABLE;
 import static org.akaza.openclinica.lctable.LCTableColumnDef.NO_FILTER;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.VISIBLE;
 import static org.akaza.openclinica.lctable.LCTableColumnDef.customTdCol;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.customTdColWithContext;
 import static org.akaza.openclinica.lctable.LCTableColumnDef.textCol;
+import static org.akaza.openclinica.lctable.LCTableColumnDef.textColHidden;
+import static org.akaza.openclinica.lctable.LCTableFilterDef.clearFilter;
 import static org.akaza.openclinica.lctable.SafeUrl.url;
+import static org.akaza.openclinica.lctable.LCTableText.key;
+import static org.akaza.openclinica.lctable.LCTableText.literal;
 
 public class LCTableTest extends TestCase {
 
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        ResourceBundleProvider.updateLocale(Locale.ENGLISH);
+        ResourceBundleProvider.updateLocale(Locale.JAPANESE);
+    }
+
     public void testRendersRowCellPopupAndActionTestAttributes() {
+        ResourceBundle mockResword = mock(ResourceBundle.class);
+        
         LCPopup<Row, String> popup = new LCPopup<>(
             row -> List.of("item"),
             (trigger, items) -> trigger.text("trigger"),
@@ -45,25 +65,27 @@ public class LCTableTest extends TestCase {
                 }
             },
             "event-trigger",
-            "TestPopup"
+            "TestPopup",
+            mockResword
         );
 
         LCTableColumnDef<Row> popupColumn = customTdCol(
-            "event", "Event", 0, NOT_SORTABLE, NO_FILTER,
-            (td, row) -> popup.render(td, row)
+            "event", literal("Event"), null, 0, NOT_SORTABLE, NO_FILTER,
+            popup::render
         );
         popupColumn.setTestAttributes(row -> Map.of("event", row.event));
 
         LCTable<Row> table = new LCTable<>(
             "testTable",
-            List.of(textCol("subject", "Subject", 0, row -> row.subject), popupColumn),
+            List.of(textCol("subject", key("subject"), "subject", 0, row -> row.subject), popupColumn),
             params -> new LCTableData<>(List.of(new Row("M-001", "Baseline")), 1)
         ).setRowTestAttributes(row -> Map.of("subject", row.subject));
 
-        String html = table.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "");
+        String html = table.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "", Locale.ENGLISH);
 
         assertTrue(html.contains("data-test-subject=\"M-001\""));
         assertTrue(html.contains("data-test-event=\"Baseline\""));
+        assertTrue(html.contains("data-test-column=\"subject\""));
         assertTrue(html.contains("data-testid=\"lc-popup-trigger\""));
         assertTrue(html.contains("data-testid=\"lc-popup-header\""));
         assertTrue(html.contains("data-testid=\"lc-popup-body\""));
@@ -74,7 +96,7 @@ public class LCTableTest extends TestCase {
     }
 
     public void testOmitsNullAndEmptyTestAttributeValues() {
-        LCTableColumnDef<Row> column = textCol("subject", "Subject", 0, row -> row.subject);
+        LCTableColumnDef<Row> column = textCol("subject", literal("Subject"), null, 0, row -> row.subject);
         column.setTestAttributes(row -> {
             java.util.LinkedHashMap<String, String> attributes = new java.util.LinkedHashMap<>();
             attributes.put("null-value", null);
@@ -89,11 +111,113 @@ public class LCTableTest extends TestCase {
             params -> new LCTableData<>(List.of(new Row("M-001", "Baseline")), 1)
         );
 
-        String html = table.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "");
+        String html = table.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "", Locale.ENGLISH);
 
         assertTrue(html.contains("data-test-subject=\"M-001\""));
         assertFalse(html.contains("data-test-null-value"));
         assertFalse(html.contains("data-test-empty-value"));
+        int bodyStart = html.indexOf("<tbody");
+        int bodyEnd = html.indexOf("</tbody>");
+        assertTrue(html, bodyStart >= 0 && bodyEnd > bodyStart);
+        assertFalse(html, html.substring(bodyStart, bodyEnd).contains("data-test-column"));
+    }
+
+    public void testReusedTableResolvesTextForEachRequestLocale() {
+        LCTable<Row> table = new LCTable<>(
+            "testTable",
+            List.of(textCol("subject", key("subject"), "subject", 0, row -> row.subject)),
+            params -> new LCTableData<>(List.of(new Row("M-001", "Baseline")), 1)
+        );
+        LCTableParams params = new LCTableParams(0, 15, "", "asc", Collections.emptyMap());
+
+        String english = table.render("/test", params, "", Locale.ENGLISH);
+        String japanese = table.render("/test", params, "", Locale.JAPANESE);
+
+        assertTrue(english, english.contains("Subject"));
+        assertTrue(japanese, japanese.contains("\u88ab\u9a13\u8005"));
+        assertTrue(english.contains("data-test-column=\"subject\""));
+        assertTrue(japanese.contains("data-test-column=\"subject\""));
+    }
+
+    public void testRejectsDuplicateKeyBackedHeaders() {
+        try {
+            new LCTable<>("testTable", List.of(
+                textCol("subject1", key("subject"), "subject", 0, (Row row) -> row.subject),
+                textCol("subject2", key("subject"), "subject", 0, (Row row) -> row.subject)
+            ), params -> new LCTableData<>(List.of(), 0));
+            fail("Expected duplicate resource keys to be rejected");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("subject"));
+        }
+    }
+
+    public void testRejectsExplicitColumnAttributeForKeyBackedCell() {
+        LCTableColumnDef<Row> column = textCol("subject", key("subject"), "subject", 0, (Row row) -> row.subject)
+            .setTestAttributes((Row row) -> Map.of("column", "legacy"));
+        LCTable<Row> table = new LCTable<>("testTable", List.of(column),
+            params -> new LCTableData<>(List.of(new Row("M-001", "Baseline")), 1));
+
+        try {
+            table.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "", Locale.ENGLISH);
+            fail("Expected conflicting column attributes to be rejected");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("subject"));
+        }
+    }
+
+    public void testContextAwareCustomCellMergesAttributesAndRejectsColumnCollision() {
+        LCTableColumnDef<Row> column = customTdColWithContext(
+            "subject", key("subject"), "subject", 0, NOT_SORTABLE, NO_FILTER,
+            (Row row) -> row.subject, (td, row, context) -> td.text(row.subject)
+        ).setTestAttributes(row -> Map.of("subject", row.subject));
+        LCTable<Row> table = new LCTable<>("testTable", List.of(column),
+            params -> new LCTableData<>(List.of(new Row("M-001", "Baseline")), 1));
+        LCTableParams params = new LCTableParams(0, 15, "", "asc", Collections.emptyMap());
+
+        String html = table.render("/test", params, "", Locale.ENGLISH);
+
+        assertTrue(html.contains("data-test-column=\"subject\""));
+        assertTrue(html.contains("data-test-subject=\"M-001\""));
+
+        column.setTestAttributes(row -> Map.of("column", "legacy"));
+        try {
+            table.render("/test", params, "", Locale.ENGLISH);
+            fail("Expected conflicting context-aware column attributes to be rejected");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("subject"));
+        }
+    }
+
+    public void testSharedChromeUsesRequestLocaleAndEnglishFallback() {
+        LCTable<Row> table = new LCTable<>(
+            "testTable",
+            List.of(
+                textCol("subject", key("subject"), "subject", 0, VISIBLE, NOT_SORTABLE, clearFilter(), row -> row.subject),
+                textColHidden("details", key("details"), "details", 0, row -> row.event)
+            ),
+            params -> new LCTableData<>(List.of(new Row("M-001", "Baseline")), 1)
+        );
+
+        String japanese = table.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "", Locale.JAPANESE);
+
+        assertTrue(japanese.contains("\u30d5\u30a3\u30eb\u30bf\u30fc\u3092\u30af\u30ea\u30a2"));
+        assertTrue(japanese.contains("\u3082\u3063\u3068\u8868\u793a"));
+        assertTrue(japanese.contains("Results 1-1 of 1."));
+
+        LCTable<Row> emptyTable = new LCTable<>("emptyTable",
+            List.of(textCol("subject", key("subject"), "subject", 0, row -> row.subject)),
+            params -> new LCTableData<>(List.of(), 0));
+        String english = emptyTable.render("/test", new LCTableParams(0, 15, "", "asc", Collections.emptyMap()), "", Locale.ENGLISH);
+        assertTrue(english.contains("No results."));
+    }
+
+    public void testSelectParsesStableUrlValueInsteadOfDisplayLabel() {
+        LCTableFilterDef.Select<String> filter = new LCTableFilterDef.Select<>(
+            List.of("ACTIVE"), value -> "Localized active", String::toLowerCase
+        );
+
+        assertEquals(Optional.of("ACTIVE"), filter.parseParam("active"));
+        assertEquals(Optional.empty(), filter.parseParam("Localized active"));
     }
 
     private static final class Row {


### PR DESCRIPTION
This PR contains two main changes:

1. localisation for LCTable library and migrated tables;
2. changes concerning the `data-test-column` attribute.

# 1. Localisation for LCTable library and migrated tables

Request-locale-aware localisation has been implemented in the LCTable library rendering.

Additionally, all tables already migrated from jmesa to LCTable have been fully localised:

- `AuditUserLoginTable`
- `ListStudySubjectTable`
- `ListEventsForSubjectTable`
- `ListNotesTable`
- `StudyAuditLogTable`

To implement localisation, a substantial change in LCTable was necessary:

1. the `columnDisplayName` displayed in column headers when the table is rendered cannot be a hard-coded string literal;
2. accordingly, `columnDisplayName` must hold a bundle key instead of a display string, and resolve it with the locale at `render()` time (according to @z10000's proposal in https://github.com/reliatec-gmbh/LibreClinica/issues/74#issuecomment-5139880727);
3. however, for some columns which are dynamically generated (e.g., the event columns of the `ListStudySubjects` view of the Subject Matrix, or the CRF columns of the `ListEventsForSubjects` view), this is not possible;
4. therefore, a new class `LCTableText` was introduced to represent a display string that is *either* a bundle key *or* a string to be displayed literally (possibly dynamically generated, in general not a constant): corresponding factory methods `key` and `literal` are provided.

The specification of the columns of a table changes accordingly. For example, see the definition of the `ListStudySubjectTable` class:
```java
        ...
        // this column is static => use 'key' with bundle key
        columns.add(textCol("studySubject.label", key("study_subject_ID"), ...));
        ...
        // some dynamic columns are generated here
        for (StudyGroupClassBean sgc : studyGroupClasses) {
            List<StudyGroupBean> groupOptions = studyGroupDAO.findAllByGroupClass(sgc);
            // => use 'literal' with column name to be displayed
            columns.add(enumColNotSortable("sgc_" + sgc.getId(), literal(sgc.getName()), ...));
        }
        ...
```

# 2. `data-test-column` test attribute

The value of the (optional) `data-test-column` HTML attribute used for testing (`LCTableColumnDef.columnTestName`) is now independent from the column name (`LCTableColumnDef.columnName`) and the column display name (`LCTableColumnDef.columnDisplayName`).

It must be specified explicitly in column definitions. However, it can be `null` if one wants to omit the `data-test-column` attribute from the cells of the given column.

Before this change, the value used for the `data-test-column` was usually the resource key used for the localisation of the column header text. This was done to avoid introducing a third name for the same column. However, this has now been changed to avoid breaking tests if bundle keys are renamed. Furthermore, with this change, the `data-test-column` attribute is generated automatically and systematically for all tables as a part of the table rendering and does not need to be manually specified in the definition of the cell's content (i.e. in the cell renderer).

Using the same example as above (`ListStudySubjectTable`):
```java
        columns.add(textCol("studySubject.label", key("study_subject_ID"), "study-subject-id", ...));
```
Here, `"studySubject.label"` is the internal column name, `"study_subject_ID"` is the resource key for the localised column display name, and finally `"study-subject-id"` is the value of the `data-test-column` test attribute to be included in the HTML elements (`td` elements) for the cells of this column.